### PR TITLE
WIP: IOExec enhancements

### DIFF
--- a/modules/IOUtils.tla
+++ b/modules/IOUtils.tla
@@ -12,13 +12,13 @@ IODeserialize(absoluteFilename, compressed) == CHOOSE val : TRUE
 
 ----------------------------------------------------------------------------
 
-IOExec(command, parameters) == 
-  (*************************************************************************)
-  (* Spawns the given printf-style command as a sub-process of TLC.  The   *)
-  (* n-th flag in command is substituted for the n-th element of the       *)
-  (* sequence parameters: IOExec("ls %s %s", <<"-lah", "/tmp">>)           *)
-  (* see http://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html *)
-  (*************************************************************************)
+IOExec(command) ==
+  (*******************************************************************************)
+  (* Spawns the given command as a sub-process of TLC.  The sequence of sequence *)
+  (* of strings `command' signifies the external program file to be invoked and  *)
+  (* its arguments: IOExec(<<"ls", "-lah", "/tmp">>)                             *)
+  (* see https://docs.oracle.com/javase/7/docs/api/java/lang/ProcessBuilder.html *)
+  (*******************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
 ============================================================================

--- a/modules/IOUtils.tla
+++ b/modules/IOUtils.tla
@@ -21,4 +21,13 @@ IOExec(command) ==
   (*******************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
+IOExecTemplate(commandTemplate, parameters) ==
+  (*************************************************************************)
+  (* Spawns the given printf-style command as a sub-process of TLC.  The   *)
+  (* n-th flag in `commandTemplate' is substituted with the n-th element   *)
+  (* of the sequence `parameters': IOExec("ls %s %s", <<"-lah", "/tmp">>)  *)
+  (* see http://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html *)
+  (*************************************************************************)
+  CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
+
 ============================================================================

--- a/tests/IOUtilsTests.tla
+++ b/tests/IOUtilsTests.tla
@@ -10,4 +10,14 @@ ASSUME(LET ret == IOExec(<<"cat",  "/does/not/exist">>) IN /\ ret.exitValue = 1
                                                            /\ ret.stdout = ""
                                                            /\ ret.stderr = "cat: /does/not/exist: No such file or directory\n")
 
+\* Spaces and quotes should be passed directly to the program.
+ASSUME(LET ret == IOExecTemplate("echo '%s'  \"%s\"", <<" foo", "bar ">>) IN /\ ret.exitValue = 0
+                                                                             /\ ret.stdout = "' foo' \"bar \"\n"
+                                                                             /\ ret.stderr = "")
+
+\* Exit values and standard error should be returned properly.
+ASSUME(LET ret == IOExecTemplate("cat /does/not/exist", <<>>) IN /\ ret.exitValue = 1
+                                                                 /\ ret.stdout = ""
+                                                                 /\ ret.stderr = "cat: /does/not/exist: No such file or directory\n")
+
 =============================================================================

--- a/tests/IOUtilsTests.tla
+++ b/tests/IOUtilsTests.tla
@@ -1,17 +1,13 @@
 ---------------------------- MODULE IOUtilsTests ----------------------------
 EXTENDS IOUtils, TLC
 
-ASSUME(LET ret == IOExec("echo %s %s", <<"foo", "bar">>) IN /\ ret.exitValue = 0 
-                                                            /\ ret.stdout = "foo bar\n"
-                                                            /\ ret.stderr = "")
-ASSUME(LET ret == IOExec("cat /does/not/exist", <<>>) IN /\ ret.exitValue = 1 
-                                                         /\ ret.stdout = ""
-                                                         /\ ret.stderr = "cat: /does/not/exist: No such file or directory\n")
-ASSUME(LET ret == IOExec("echo \"' %s", <<"\"'">>) IN /\ ret.exitValue = 0
-                                                      /\ ret.stdout = "\"' \"'\n"
-                                                      /\ ret.stderr = "")
-ASSUME(LET ret == IOExec("grep %s /dev/null", <<"foo bar">>) IN /\ ret.exitValue = 1
-                                                                /\ ret.stdout = ""
-                                                                /\ ret.stderr = "")
+\* Spaces and quotes should be passed directly to the program.
+ASSUME(LET ret == IOExec(<<"echo", "'foo' ", " \"bar\"">>) IN /\ ret.exitValue = 0
+                                                              /\ ret.stdout = "'foo'   \"bar\"\n"
+                                                              /\ ret.stderr = "")
+\* Exit values and standard error should be returned properly.
+ASSUME(LET ret == IOExec(<<"cat",  "/does/not/exist">>) IN /\ ret.exitValue = 1
+                                                           /\ ret.stdout = ""
+                                                           /\ ret.stderr = "cat: /does/not/exist: No such file or directory\n")
 
 =============================================================================

--- a/tests/IOUtilsTests.tla
+++ b/tests/IOUtilsTests.tla
@@ -7,5 +7,11 @@ ASSUME(LET ret == IOExec("echo %s %s", <<"foo", "bar">>) IN /\ ret.exitValue = 0
 ASSUME(LET ret == IOExec("cat /does/not/exist", <<>>) IN /\ ret.exitValue = 1 
                                                          /\ ret.stdout = ""
                                                          /\ ret.stderr = "cat: /does/not/exist: No such file or directory\n")
+ASSUME(LET ret == IOExec("echo \"' %s", <<"\"'">>) IN /\ ret.exitValue = 0
+                                                      /\ ret.stdout = "\"' \"'\n"
+                                                      /\ ret.stderr = "")
+ASSUME(LET ret == IOExec("grep %s /dev/null", <<"foo bar">>) IN /\ ret.exitValue = 1
+                                                                /\ ret.stdout = ""
+                                                                /\ ret.stderr = "")
 
 =============================================================================


### PR DESCRIPTION
The current `IOExec` has some problems handling quotes and spaces. This PR improves the situation by making `IOExec` just a small wrapper around Java's `ProcessBuilder`.

To keep the convenience of passing a string with `%s` placeholders, we introduce a new operator `IOExecTemplate` which takes a template string for the command. This template string is then split into words on which `%s` expansion takes place. This allows for spaces in the expanded strings. Note that for the sake of simplicity we don't handle

- multiple placeholders in a word
- more complex format specifiers than `%s`