### PR TITLE
JSON: Serialize model values as strings

### DIFF
--- a/modules/tlc2/overrides/Json.java
+++ b/modules/tlc2/overrides/Json.java
@@ -51,6 +51,7 @@ import tlc2.value.impl.FcnLambdaValue;
 import tlc2.value.impl.FcnRcdValue;
 import tlc2.value.impl.IntValue;
 import tlc2.value.impl.IntervalValue;
+import tlc2.value.impl.ModelValue;
 import tlc2.value.impl.RecordValue;
 import tlc2.value.impl.SetEnumValue;
 import tlc2.value.impl.SetOfFcnsValue;
@@ -153,6 +154,8 @@ public class Json {
       return getArrayNode((TupleValue) value);
     } else if (value instanceof StringValue) {
       return new TextNode(((StringValue) value).val.toString());
+    } else if (value instanceof ModelValue) {
+      return new TextNode(((ModelValue) value).val.toString());
     } else if (value instanceof IntValue) {
       return new IntNode(((IntValue) value).val);
     } else if (value instanceof BoolValue) {

--- a/tests/AllTests.cfg
+++ b/tests/AllTests.cfg
@@ -1,0 +1,1 @@
+CONSTANT ModelValueConstant = ModelValue

--- a/tests/JsonTests.tla
+++ b/tests/JsonTests.tla
@@ -1,6 +1,8 @@
 ----------------------------- MODULE JsonTests -----------------------------
 EXTENDS Json, Integers, Sequences, TLC, TLCExt
 
+CONSTANT ModelValueConstant
+
 \* Empty values
 ASSUME(AssertEq(ToJsonArray({}), "[]"))
 ASSUME(AssertEq(ToJsonArray(<<>>), "[]"))
@@ -8,6 +10,8 @@ ASSUME(AssertEq(ToJsonArray(<<>>), "[]"))
 \* Primitive values
 ASSUME(AssertEq(ToJson(FALSE), "false"))
 ASSUME(AssertEq(ToJson(1), "1"))
+ASSUME(AssertEq(ToJson("a"), "\"a\""))
+ASSUME(AssertEq(ToJson(ModelValueConstant), "\"ModelValue\""))
 ASSUME(AssertEq(ToJson({TRUE, FALSE}), "[false,true]"))
 ASSUME(AssertEq(ToJson({1}), "[1]"))
 ASSUME(AssertEq(ToJsonArray({TRUE, FALSE}), "[false,true]"))


### PR DESCRIPTION
Serialization would crash on model values. This is now fixed by serializing them to their string representation.