### PR TITLE
Add a type test in MapThenFoldSet

### DIFF
--- a/modules/Folds.tla
+++ b/modules/Folds.tla
@@ -2,9 +2,10 @@
 
 MapThenFoldSet(op(_,_), base, f(_), choose(_), S) ==
 (******************************************************************************)
-(* Starting from base, apply op to f(x), for all x \in S, in an ordered by    *)
-(* ord. If there is no ordering, ord can be always true but then op must be   *)
-(* associative and commutative.                                               *)
+(* Starting from base, apply op to f(x), for all x \in S, by choosing the set *)
+(* elements with `choose`. If there are multiple ways for choosing an element,*)
+(* op should be associative and commutative. Otherwise, the result may depend *)
+(* on the concrete implementation of `choose`.                                *)
 (*                                                                            *)
 (* FoldSet, a simpler version for sets is contained in FiniteSetsEx.          *)
 (* FoldFunction, a simpler version for functions is contained in Functions.   *)
@@ -12,7 +13,12 @@ MapThenFoldSet(op(_,_), base, f(_), choose(_), S) ==
 (*                                                                            *)
 (* Example:                                                                   *)
 (*                                                                            *)
-(*  MapThenFoldSet(LAMBDA x,y: x \cup y,{1,2},LAMBDA x: {{x}}, S) = {{1},{2}} *)
+(*  MapThenFoldSet(LAMBDA x,y: x \cup y,                                      *)
+(*                 {1,2},                                                     *)
+(*                 LAMBDA x: {{x}},                                           *)
+(*                 LAMBDA set: CHOOSE x \in set: TRUE,                        *)
+(*                 S)                                                         *)
+(*       = {{1},{2}}                                                          *)
 (******************************************************************************)
   \* By comparing S to {}, we help TLC in producing a reasonable error trace
   IF S = {}


### PR DESCRIPTION
I ran into an issue with TLC and folds several times. If somebody passes an integer instead of a set for the parameter `S`, TLC produces an unreadable error for the definition of `iter[s \in SUBSET S]`. There is a simple fix for that: We can compare `S` to the empty set. If someone passed a non-set, TLC would complain and produce a nice error trace.