### PR TITLE
Add text writer and reader using the new serializer interface

### DIFF
--- a/modules/IOUtils.tla
+++ b/modules/IOUtils.tla
@@ -14,13 +14,13 @@ Serialize(value, dest, options) ==
     (* value: TLA+ value to be serialized. *)
     (* dest: Destination to serialize to such as a file or URL. *)
     (* options: Record of serializer-specific options. *)
-    (* options must include record "ser" with a String identifying the serializer. *)
+    (* options must include record "format" with a String identifying the serializer. *)
     CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
 Deserialize(src, options) ==
     (* dest: Destination to serialize to such as a file or URL. *)
     (* options: Record of serializer-specific options. *)
-    (* options must include record "ser" with a String identifying the serializer. *)
+    (* options must include record "format" with a String identifying the serializer. *)
     CHOOSE val : TRUE
 
 ----------------------------------------------------------------------------

--- a/modules/IOUtils.tla
+++ b/modules/IOUtils.tla
@@ -10,6 +10,19 @@ IOSerialize(val, absoluteFilename, compress) == TRUE
 
 IODeserialize(absoluteFilename, compressed) == CHOOSE val : TRUE
 
+Serialize(value, dest, options) ==
+    (* value: TLA+ value to be serialized. *)
+    (* dest: Destination to serialize to such as a file or URL. *)
+    (* options: Record of serializer-specific options. *)
+    (* options must include record "ser" with a String identifying the serializer. *)
+    CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
+
+Deserialize(src, options) ==
+    (* dest: Destination to serialize to such as a file or URL. *)
+    (* options: Record of serializer-specific options. *)
+    (* options must include record "ser" with a String identifying the serializer. *)
+    CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
+
 ----------------------------------------------------------------------------
 
 IOExec(command) ==

--- a/modules/IOUtils.tla
+++ b/modules/IOUtils.tla
@@ -21,7 +21,7 @@ Deserialize(src, options) ==
     (* dest: Destination to serialize to such as a file or URL. *)
     (* options: Record of serializer-specific options. *)
     (* options must include record "ser" with a String identifying the serializer. *)
-    CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
+    CHOOSE val : TRUE
 
 ----------------------------------------------------------------------------
 

--- a/modules/tlc2/overrides/IOUtils.java
+++ b/modules/tlc2/overrides/IOUtils.java
@@ -84,15 +84,15 @@ public class IOUtils {
 		return BoolValue.ValTrue;
 	}
 	
-	/* Writes a String as plain text to file.
-	 * Operator should be called as Serialize(payload, filepath, [ser |-> "TXT", openOption |-> openOption, charset |-> charset])
+	/* Writes a String as plain text to a file.
+	 * Operator should be called as Serialize(payload, filepath, [ser |-> "TXT", openOptions |-> openOptions, charset |-> charset])
 	 *		String payload: is the string that will be written
 	 *      String filepath: is the file where the string will be written
 	 *      String openOptions: sequence of strings of java StandardOpenOptions
 	 *      String charset: string with a java standard charset
 	 *      
 	 * Example:
-	 * 		Serialize("test payload", "test.txt", [ser |-> "TXT", charset |-> "UTF-8", openOption |-> <<"WRITEA", "CREATE", "TRUNCATE_EXISTING">>])
+	 * 		Serialize("test payload", "test.txt", [ser |-> "TXT", charset |-> "UTF-8", openOptions |-> <<"WRITEA", "CREATE", "TRUNCATE_EXISTING">>])
 	 */
 	@Evaluation(definition = "Serialize", module = "IOUtils", warn = false, silent = true, priority = 50)
 	public synchronized static Value textSerialize(final Tool tool, final ExprOrOpArgNode[] args, final Context c,

--- a/modules/tlc2/overrides/IOUtils.java
+++ b/modules/tlc2/overrides/IOUtils.java
@@ -85,14 +85,14 @@ public class IOUtils {
 	}
 	
 	/* Writes a String as plain text to a file.
-	 * Operator should be called as Serialize(payload, filepath, [ser |-> "TXT", openOptions |-> openOptions, charset |-> charset])
-	 *		String payload: is the string that will be written
+	 * Operator should be called as Serialize(payload, filepath, [format |-> "TXT", charset |-> charset, openOptions |-> openOptions])
+	 *      String payload: is the string that will be written
 	 *      String filepath: is the file where the string will be written
-	 *      String openOptions: sequence of strings of java StandardOpenOptions
 	 *      String charset: string with a java standard charset
+	 *      String openOptions: sequence of strings of java StandardOpenOptions
 	 *      
 	 * Example:
-	 * 		Serialize("test payload", "test.txt", [ser |-> "TXT", charset |-> "UTF-8", openOptions |-> <<"WRITEA", "CREATE", "TRUNCATE_EXISTING">>])
+	 *      Serialize("test payload", "test.txt", [format |-> "TXT", charset |-> "UTF-8", openOptions |-> <<"WRITEA", "CREATE", "TRUNCATE_EXISTING">>])
 	 */
 	@Evaluation(definition = "Serialize", module = "IOUtils", warn = false, silent = true, priority = 50)
 	public synchronized static Value textSerialize(final Tool tool, final ExprOrOpArgNode[] args, final Context c,
@@ -109,7 +109,7 @@ public class IOUtils {
 			return new RecordValue(EXEC_NAMES, new Value[] { IntValue.ValOne, new StringValue(""), new StringValue(msgInvalidParam + e.toString()) }, false);
 		}
 		
-		final StringValue serializer = (StringValue) opts.apply(new StringValue("ser"), EvalControl.Clear);
+		final StringValue serializer = (StringValue) opts.apply(new StringValue("format"), EvalControl.Clear);
 		if("TXT".equals(serializer.getVal().toString())) {
 			
 			final StringValue payload;
@@ -151,12 +151,12 @@ public class IOUtils {
 	}
 
 	/* Reads a String from a plain text file.
-	 * Operator should be called as Deserialize(filepath, [ser |-> "TXT", charset |-> charset])
+	 * Operator should be called as Deserialize(filepath, [format |-> "TXT", charset |-> charset])
 	 *      String filepath: is the file to be read
 	 *      String charset: string with a java standard charset
 	 *      
 	 * Example:
-	 * 		Deserialize("test.txt", [ser |-> "TXT", charset |-> "UTF-8"])
+	 *      Deserialize("test.txt", [format |-> "TXT", charset |-> "UTF-8"])
 	 */
 	@Evaluation(definition = "Deserialize", module = "IOUtils", warn = false, silent = true, priority = 50)
 	public synchronized static Value textDeserialize(final Tool tool, final ExprOrOpArgNode[] args, final Context c,
@@ -172,7 +172,7 @@ public class IOUtils {
 			return new RecordValue(EXEC_NAMES, new Value[] { IntValue.ValOne, new StringValue(""), new StringValue(msgInvalidParam + e.toString()) }, false);
 		}
 		
-		final StringValue serializer = (StringValue) opts.apply(new StringValue("ser"), EvalControl.Clear);
+		final StringValue serializer = (StringValue) opts.apply(new StringValue("format"), EvalControl.Clear);
 		if("TXT".equals(serializer.getVal().toString())) {
 			
 			final StringValue filepath;

--- a/modules/tlc2/overrides/IOUtils.java
+++ b/modules/tlc2/overrides/IOUtils.java
@@ -104,7 +104,7 @@ public class IOUtils {
 		final RecordValue opts;	
 		
 		try {
-			opts = (RecordValue) tool.eval(args[2]);
+			opts = (RecordValue) tool.eval(args[2], c, s0, s1, control, cm);
 		} catch (Exception e){
 			return new RecordValue(EXEC_NAMES, new Value[] { IntValue.ValOne, new StringValue(""), new StringValue(msgInvalidParam + e.toString()) }, false);
 		}
@@ -118,8 +118,8 @@ public class IOUtils {
 			final StringValue charset;
 			
 			try {
-				payload = (StringValue) tool.eval(args[0]);
-				filepath = (StringValue) tool.eval(args[1]);
+				payload = (StringValue) tool.eval(args[0], c, s0, s1, control, cm);
+				filepath = (StringValue) tool.eval(args[1], c, s0, s1, control, cm);
 				final TupleValue openOptionstv = (TupleValue) opts.apply(new StringValue("openOptions"), EvalControl.Clear);
 				charset = (StringValue) opts.apply(new StringValue("charset"), EvalControl.Clear);
 				
@@ -167,7 +167,7 @@ public class IOUtils {
 		final RecordValue opts;	
 		
 		try {
-			opts = (RecordValue) tool.eval(args[1]);
+			opts = (RecordValue) tool.eval(args[1], c, s0, s1, control, cm);
 		} catch (Exception e){
 			return new RecordValue(EXEC_NAMES, new Value[] { IntValue.ValOne, new StringValue(""), new StringValue(msgInvalidParam + e.toString()) }, false);
 		}
@@ -179,7 +179,7 @@ public class IOUtils {
 			final StringValue charset;
 			
 			try {
-				filepath = (StringValue) tool.eval(args[0]);
+				filepath = (StringValue) tool.eval(args[0], c, s0, s1, control, cm);
 				charset = (StringValue) opts.apply(new StringValue("charset"), EvalControl.Clear);
 			} catch(Exception e) {
 				return new RecordValue(EXEC_NAMES, new Value[] { IntValue.ValOne, new StringValue(""), new StringValue(msgInvalidParam + e.toString()) }, false);

--- a/tests/IOUtilsTests.tla
+++ b/tests/IOUtilsTests.tla
@@ -138,4 +138,23 @@ ASSUME(LET ret == IOEnvExec([SOME_NESTED_VAR |-> "SOME_VAL", B |-> "23"],
                                                                  IN /\ PrintT(ret)
                                                                     /\ ret.exitValue = 0
                                                                     /\ ret.stderr = "")
+
+---------------------------------------------------------------------------------------------------------------------------
+
+ASSUME PrintT("IOUtilsTests!D")
+
+ASSUME PrintT("IOUtilsTests!D!A")
+
+file == "/tmp/txt-serialize-test.txt"
+payloadTXT == "Some text with \" escapes \" \\"
+
+TXTSerializeResult == Serialize(payloadTXT, file, [ser |-> "TXT", charset |-> "UTF-8", openOptions |-> <<"WRITE", "CREATE", "TRUNCATE_EXISTING">>])
+ASSUME(LET ret == TXTSerializeResult IN /\ ret.exitValue = 0
+                                        /\ ret.stderr = "")
+
+TXTDeserializeResult == Deserialize(file, [ser |-> "TXT", charset |-> "UTF-8"])
+ASSUME(LET ret == TXTDeserializeResult IN /\ ret.exitValue = 0
+                                          /\ ret.stdout = payloadTXT
+                                          /\ ret.stderr = "")
+
 =============================================================================

--- a/tests/IOUtilsTests.tla
+++ b/tests/IOUtilsTests.tla
@@ -148,11 +148,11 @@ ASSUME PrintT("IOUtilsTests!D!A")
 file == "/tmp/txt-serialize-test.txt"
 payloadTXT == "Some text with \" escapes \" \\"
 
-TXTSerializeResult == Serialize(payloadTXT, file, [ser |-> "TXT", charset |-> "UTF-8", openOptions |-> <<"WRITE", "CREATE", "TRUNCATE_EXISTING">>])
+TXTSerializeResult == Serialize(payloadTXT, file, [format |-> "TXT", charset |-> "UTF-8", openOptions |-> <<"WRITE", "CREATE", "TRUNCATE_EXISTING">>])
 ASSUME(LET ret == TXTSerializeResult IN /\ ret.exitValue = 0
                                         /\ ret.stderr = "")
 
-TXTDeserializeResult == Deserialize(file, [ser |-> "TXT", charset |-> "UTF-8"])
+TXTDeserializeResult == Deserialize(file, [format |-> "TXT", charset |-> "UTF-8"])
 ASSUME(LET ret == TXTDeserializeResult IN /\ ret.exitValue = 0
                                           /\ ret.stdout = payloadTXT
                                           /\ ret.stderr = "")


### PR DESCRIPTION
Add serializer interface to module IOUtils using the new evaluation interface with priority added in https://github.com/tlaplus/tlaplus/commit/224936696851dd4ec8ea2e49e81fee32140afc52 and https://github.com/tlaplus/tlaplus/commit/f4803418873d02f14ce3fa5f2849839a454a1aa9.

Add new TXT file writer and reader operators using the new serializer interface.

Reference: #53 