### PR TITLE
annotate operators with the @supportedBy tag

### DIFF
--- a/modules/BagsExt.tla
+++ b/modules/BagsExt.tla
@@ -7,6 +7,7 @@ LOCAL INSTANCE Bags
 LOCAL INSTANCE Integers
 LOCAL INSTANCE Folds
 
+\* @supportedBy("TLC,Apalache")
 BagAdd(B, x) ==
    (************************************************************************)
    (* Add an element x to bag B.                                           *)
@@ -16,6 +17,7 @@ BagAdd(B, x) ==
    THEN [e \in DOMAIN B |-> IF e=x THEN B[e]+1 ELSE B[e]]
    ELSE [e \in DOMAIN B \union {x} |-> IF e=x THEN 1 ELSE B[e]]
 
+\* @supportedBy("TLC,Apalache")
 BagRemove(B,x) ==
    (************************************************************************)
    (* Remove an element x from bag B.                                      *)
@@ -27,13 +29,15 @@ BagRemove(B,x) ==
         ELSE [e \in DOMAIN B |-> IF e=x THEN B[e]-1 ELSE B[e]]
    ELSE B
 
+\* @supportedBy("TLC,Apalache")
 BagRemoveAll(B,x) ==
    (************************************************************************)
    (* Remove all copies of an element x from bag B.                        *)
    (************************************************************************)
    [e \in DOMAIN B \ {x} |-> B[e]]
  
- MapThenFoldBag(op(_,_), base, f(_), choose(_), B) ==
+\* @supportedBy("TLC")
+MapThenFoldBag(op(_,_), base, f(_), choose(_), B) ==
     (***********************************************************************)
     (* Fold operation op over the images through f of all elements of bag  *)
     (* B, starting from base. The parameter choose indicates the order in  *)
@@ -69,6 +73,7 @@ BagRemoveAll(B,x) ==
                        LAMBDA S : CHOOSE x \in S : TRUE,
                        DOMAIN B)
 
+\* @supportedBy("TLC")
 FoldBag(op(_,_), base, B) ==
    (************************************************************************)
    (* Fold op over all elements of bag B, starting with value base.        *)
@@ -81,12 +86,14 @@ FoldBag(op(_,_), base, B) ==
    (************************************************************************)
    MapThenFoldBag(op, base, LAMBDA x: x, LAMBDA S : CHOOSE x \in S : TRUE, B)
 
+\* @supportedBy("TLC,Apalache")
 SumBag(B) ==
    (************************************************************************)
    (* Compute the sum of the elements of B.                                *)
    (************************************************************************)
    FoldBag(LAMBDA x,y : x+y, 0, B)
 
+\* @supportedBy("TLC,Apalache")
 ProductBag(B) ==
    (************************************************************************)
    (* Compute the product of the elements of B.                            *)

--- a/modules/Bitwise.tla
+++ b/modules/Bitwise.tla
@@ -3,6 +3,7 @@ LOCAL INSTANCE Integers
 
 \* https://en.wikipedia.org/wiki/Bitwise_operation#Mathematical_equivalents
 RECURSIVE And(_,_,_,_)
+\* @supportedBy("TLC")
 LOCAL And(x,y,n,m) == 
         LET exp == 2^n
         IN IF m = 0 
@@ -10,6 +11,7 @@ LOCAL And(x,y,n,m) ==
            ELSE exp * ((x \div exp) % 2) * ((y \div exp) % 2) 
                     + And(x,y,n+1,m \div 2)
 
+\* @supportedBy("TLC")
 x & y == 
     (***************************************************************************)
     (* Bitwise AND of (non-negative) x and y (defined for Nat \cup {0}).       *)
@@ -19,6 +21,7 @@ x & y ==
 -------------------------------------------------------------------------------
 
 RECURSIVE Or(_,_,_,_)
+\* @supportedBy("TLC")
 LOCAL Or(x,y,n,m) == 
         LET exp == 2^n
             xdm == (x \div exp) % 2
@@ -28,6 +31,7 @@ LOCAL Or(x,y,n,m) ==
            ELSE exp * (((xdm + ydm) + (xdm * ydm)) % 2)
                         + Or(x,y,n+1,m \div 2)
 
+\* @supportedBy("TLC")
 x | y == 
     (***************************************************************************)
     (* Bitwise OR of (non-negative) x and y (defined for Nat \cup {0}).        *)
@@ -37,6 +41,7 @@ x | y ==
 -------------------------------------------------------------------------------
 
 RECURSIVE Xor(_,_,_,_)
+\* @supportedBy("TLC")
 LOCAL Xor(x,y,n,m) == 
         LET exp == 2^n
         IN IF m = 0 
@@ -44,6 +49,7 @@ LOCAL Xor(x,y,n,m) ==
            ELSE exp * (((x \div exp) + (y \div exp)) % 2) 
                     + Xor(x,y,n+1,m \div 2)
 
+\* @supportedBy("TLC")
 x ^^ y ==   \* single "^" already taken by Naturals.tla
     (***************************************************************************)
     (* Bitwise XOR of (non-negative) x and y (defined for Nat \cup {0}).       *)
@@ -53,6 +59,7 @@ x ^^ y ==   \* single "^" already taken by Naturals.tla
 -------------------------------------------------------------------------------
 
 RECURSIVE NotR(_,_,_)
+\* @supportedBy("TLC")
 LOCAL NotR(x,n,m) == 
     LET exp == 2^n
         xdm == (x \div exp) % 2
@@ -61,6 +68,7 @@ LOCAL NotR(x,n,m) ==
         ELSE exp * ((xdm + 1) % 2)
                     + NotR(x,n+1,m \div 2)
 
+\* @supportedBy("TLC")
 Not(a) ==
     (***************************************************************************)
     (* Bitwise NOT of (non-negative) x (defined for Nat \cup {0}).             *)
@@ -70,6 +78,7 @@ Not(a) ==
 -------------------------------------------------------------------------------
 
 RECURSIVE shiftR(_,_)
+\* @supportedBy("TLC")
 shiftR(n,pos) == 
     (***************************************************************************)
     (* Logical bit-shifting the (non-negative) n by pos positions to the right *)

--- a/modules/CSV.tla
+++ b/modules/CSV.tla
@@ -6,6 +6,7 @@ LOCAL INSTANCE Integers
   (* Imports the definitions from the modules, but doesn't export them.    *)
   (*************************************************************************)
 
+\* @supportedBy("TLC")
 CSVWrite(template, val, file) == 
    (*
        CSVWrite("%1$s#%2$s#%3$s", 
@@ -13,6 +14,7 @@ CSVWrite(template, val, file) ==
     *)
    TRUE
 
+\* @supportedBy("TLC")
 CSVRead(columns, delimiter, file) == 
    (*
        CSVRead(<<"C1", "C2", "C3">>, "#", "/tmp/out.csv")
@@ -22,6 +24,7 @@ CSVRead(columns, delimiter, file) ==
    TRUE
 
 
+\* @supportedBy("TLC")
 CSVRecords(file) == 
    (* The number of records in the given file (including headers if any). *)
    CHOOSE n : n \in Nat

--- a/modules/Combinatorics.tla
+++ b/modules/Combinatorics.tla
@@ -1,9 +1,11 @@
 ------------------------- MODULE Combinatorics -------------------------
 EXTENDS Naturals
 
+\* @supportedBy("TLC")
 factorial[n \in Nat] == 
     IF n = 0 THEN 1 ELSE n * factorial[n-1]
 
+\* @supportedBy("TLC")
 choose(n, k) ==
     factorial[n] \div (factorial[k] * factorial[n - k])
 

--- a/modules/DifferentialEquations.tla
+++ b/modules/DifferentialEquations.tla
@@ -1,9 +1,13 @@
 ----------------------- MODULE DifferentialEquations ------------------------
 LOCAL INSTANCE Reals
 LOCAL INSTANCE Sequences
+\* @supportedBy("TLC")
 LOCAL PosReal == {r \in Real : r > 0}
+\* @supportedBy("TLC")
 LOCAL OpenInterval(a, b) == {s \in Real : a < s /\ s < b}
+\* @supportedBy("TLC")
 LOCAL Nbhd(r,e) ==  OpenInterval(r-e, r+e)
+\* @supportedBy("TLC")
 LOCAL IsFirstDeriv(df, f) ==
         /\ df \in [DOMAIN f -> Real]
         /\ \A r \in DOMAIN f : 
@@ -12,6 +16,7 @@ LOCAL IsFirstDeriv(df, f) ==
                     \A s \in Nbhd(r,d) \ {r} :
                         (f[s] - f[r])/(s - r) \in Nbhd(df[r], e)
 
+\* @supportedBy("TLC")
 LOCAL IsDeriv(n, df, f) == 
   LET IsD[k \in 0..n,  g \in [DOMAIN f -> Real]] ==
          IF k = 0 
@@ -20,6 +25,7 @@ LOCAL IsDeriv(n, df, f) ==
                                                /\ IsD[k-1, gg]
   IN  IsD[n, df]
 
+\* @supportedBy("TLC")
 Integrate(D, a, b, InitVals) ==
   LET n == Len(InitVals)
       gg == CHOOSE g : 

--- a/modules/FiniteSetsExt.tla
+++ b/modules/FiniteSetsExt.tla
@@ -4,6 +4,7 @@ LOCAL INSTANCE FiniteSets
 LOCAL INSTANCE Functions
 LOCAL INSTANCE Folds
 
+\* @supportedBy("TLC,Apalache")
 FoldSet(op(_,_), base, set) ==
    (*************************************************************************)
    (* Fold op over the elements of set using base as starting value.        *)
@@ -13,6 +14,7 @@ FoldSet(op(_,_), base, set) ==
    (*************************************************************************)
    MapThenFoldSet(op, base, LAMBDA x : x, LAMBDA s : CHOOSE x \in s : TRUE, set)
 
+\* @supportedBy("TLC,Apalache")
 SumSet(set) ==
    (*************************************************************************)
    (* Calculate the sum of the elements in set.                             *)
@@ -22,6 +24,7 @@ SumSet(set) ==
    (*************************************************************************)
    FoldSet(+, 0, set)
 
+\* @supportedBy("TLC,Apalache")
 ProductSet(set) ==
    (*************************************************************************)
    (* Calculuate the product of the elements in set.                        *)
@@ -31,6 +34,7 @@ ProductSet(set) ==
    (*************************************************************************)
    FoldSet(LAMBDA x, y: x * y, 1, set)
 
+\* @supportedBy("TLC,Apalache")
 ReduceSet(op(_, _), set, acc) == 
    (*************************************************************************)
    (* An alias for FoldSet. ReduceSet was used instead of FoldSet in        *)
@@ -39,6 +43,7 @@ ReduceSet(op(_, _), set, acc) ==
    FoldSet(op, set, acc)
 
 
+\* @supportedBy("TLC,Apalache")
 FlattenSet(S) ==
 (******************************************************************************)
 (* Starting from base, apply op to f(x), for all x \in S, in an arbitrary     *)
@@ -57,10 +62,12 @@ FlattenSet(S) ==
 (* elements that are present in either A or B but not in their             *)
 (* intersection.                                                           *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 SymDiff(A, B) == (A \ B) \cup (B \ A)
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 Quantify(S, P(_)) ==
    (*************************************************************************)
    (* Quantify the elements in S matching the predicate (LAMDBA) P.         *)
@@ -76,6 +83,7 @@ Quantify(S, P(_)) ==
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 kSubset(k, S) == 
    (*************************************************************************)
    (* A k-subset ks of a set S has Cardinality(ks) = k.  The number of      *)
@@ -98,7 +106,10 @@ kSubset(k, S) ==
 (* We define Max(S) and Min(S) to be the maximum and minimum,              *)
 (* respectively, of a finite, non-empty set S of integers.                 *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Max(S) == CHOOSE x \in S : \A y \in S : x >= y
+
+\* @supportedBy("TLC,Apalache")
 Min(S) == CHOOSE x \in S : \A y \in S : x =< y
 
 -----------------------------------------------------------------------------
@@ -110,6 +121,7 @@ Min(S) == CHOOSE x \in S : \A y \in S : x =< y
 (*          Choices({{1,2}, {2,3}, {5}}) =                                 *)
 (*                         {{2, 5}, {1, 2, 5}, {1, 3, 5}, {2, 3, 5}}       *)
 (***************************************************************************) 
+\* @supportedBy("TLC,Apalache")
 Choices(Sets) == LET ChoiceFunction(Ts) == { f \in [Ts -> UNION Ts] : 
                                                \A T \in Ts : f[T] \in T }
                  IN  { Range(f) : f \in ChoiceFunction(Sets) }
@@ -129,6 +141,7 @@ Choices(Sets) == LET ChoiceFunction(Ts) == { f \in [Ts -> UNION Ts] :
 (*          ChooseUnique({2, 3, 4, 5}, LAMBDA x : x % 3 = 1) = 4           *)
 (*                                                                         *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 ChooseUnique(S, P(_)) == CHOOSE x \in S :
                               P(x) /\ \A y \in S : P(y) => y = x
 

--- a/modules/Folds.tla
+++ b/modules/Folds.tla
@@ -1,5 +1,6 @@
 ------------------------------- MODULE Folds -------------------------------
 
+\* @supportedBy("TLC")
 MapThenFoldSet(op(_,_), base, f(_), choose(_), S) ==
 (******************************************************************************)
 (* Starting from base, apply op to f(x), for all x \in S, by choosing the set *)

--- a/modules/Functions.tla
+++ b/modules/Functions.tla
@@ -11,6 +11,7 @@ LOCAL INSTANCE Folds
 (***************************************************************************)
 (* Restriction of a function to a set (should be a subset of the domain).  *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Restrict(f,S) == [ x \in S |-> f[x] ]
 
 (***************************************************************************)
@@ -18,6 +19,7 @@ Restrict(f,S) == [ x \in S |-> f[x] ]
 (* Note: The image of a set under function f can be defined as             *)
 (*       Range(Restrict(f,S)).                                             *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Range(f) == { f[x] : x \in DOMAIN f }
 
 
@@ -32,11 +34,13 @@ Range(f) == { f[x] : x \in DOMAIN f }
 (*    IN Inverse(f, DOMAIN f, {1,3}) =                                     *)
 (*                                 1 :> "b" @@ 3 :> "a")                   *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Inverse(f,S,T) == [t \in T |-> CHOOSE s \in S : t \in Range(f) => f[s] = t]
 
 (***************************************************************************)
 (* The inverse of a function.                                              *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 AntiFunction(f) == Inverse(f, DOMAIN f, Range(f))
 
 (***************************************************************************)
@@ -46,11 +50,13 @@ AntiFunction(f) == Inverse(f, DOMAIN f, Range(f))
 (* This definition is overridden by TLC in the Java class SequencesExt.    *)
 (* The operator is overridden by the Java method with the same name.       *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 IsInjective(f) == \A a,b \in DOMAIN f : f[a] = f[b] => a = b
 
 (***************************************************************************)
 (* Set of injections between two sets.                                     *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Injection(S,T) == { M \in [S -> T] : IsInjective(M) }
 
 
@@ -58,12 +64,14 @@ Injection(S,T) == { M \in [S -> T] : IsInjective(M) }
 (* A map is a surjection iff for each element in the range there is some   *)
 (* element in the domain that maps to it.                                  *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Surjection(S,T) == { M \in [S -> T] : \A t \in T : \E s \in S : M[s] = t }
 
 
 (***************************************************************************)
 (* A map is a bijection iff it is both an injection and a surjection.      *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 Bijection(S,T) == Injection(S,T) \cap Surjection(S,T)
 
 
@@ -71,12 +79,16 @@ Bijection(S,T) == Injection(S,T) \cap Surjection(S,T)
 (* An injection, surjection, or bijection exists if the corresponding set  *)
 (* is nonempty.                                                            *)
 (***************************************************************************)
+\* @supportedBy("TLC,Apalache")
 ExistsInjection(S,T)  == Injection(S,T) # {}
+\* @supportedBy("TLC,Apalache")
 ExistsSurjection(S,T) == Surjection(S,T) # {}
+\* @supportedBy("TLC,Apalache")
 ExistsBijection(S,T)  == Bijection(S,T) # {}
 
 --------------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 FoldFunction(op(_,_), base, fun) ==
   (***************************************************************************)
   (* Applies the binary function op on all elements of seq in arbitrary      *)
@@ -92,6 +104,7 @@ FoldFunction(op(_,_), base, fun) ==
   MapThenFoldSet(op, base, LAMBDA i : fun[i], LAMBDA s: CHOOSE x \in s : TRUE, DOMAIN fun)
 
 
+\* @supportedBy("TLC,Apalache")
 FoldFunctionOnSet(op(_,_), base, fun, indices) ==
   (***************************************************************************)
   (* Applies the binary function op on the given indices of seq in arbitrary *)

--- a/modules/Graphs.tla
+++ b/modules/Graphs.tla
@@ -4,30 +4,37 @@ LOCAL INSTANCE Sequences
 LOCAL INSTANCE SequencesExt
 LOCAL INSTANCE FiniteSets
 
+\* @supportedBy("TLC")
 IsDirectedGraph(G) ==
    /\ G = [node |-> G.node, edge |-> G.edge]
    /\ G.edge \subseteq (G.node \X G.node)
 
+\* @supportedBy("TLC")
 DirectedSubgraph(G) ==    
   {H \in [node : SUBSET G.node, edge : SUBSET (G.node \X G.node)] :
      IsDirectedGraph(H) /\ H.edge \subseteq G.edge}
 
+\* @supportedBy("TLC")
 Transpose(G) ==
     \* https://en.wikipedia.org/wiki/Transpose_graph
     [ edge |-> { <<e[2], e[1]>> : e \in G.edge }, 
       node |-> G.node] 
 
 -----------------------------------------------------------------------------
+\* @supportedBy("TLC")
 IsUndirectedGraph(G) ==
    /\ IsDirectedGraph(G)
    /\ \A e \in G.edge : <<e[2], e[1]>> \in G.edge
 
+\* @supportedBy("TLC")
 UndirectedSubgraph(G) == {H \in DirectedSubgraph(G) : IsUndirectedGraph(H)}
 -----------------------------------------------------------------------------
+\* @supportedBy("TLC")
 Path(G) == {p \in Seq(G.node) :
              /\ p # << >>
              /\ \A i \in 1..(Len(p)-1) : <<p[i], p[i+1]>> \in G.edge}
 
+\* @supportedBy("TLC")
 SimplePath(G) ==
     \* A simple path is a path with no repeated nodes.
     {p \in SeqOf(G.node, Cardinality(G.node)) :
@@ -35,9 +42,11 @@ SimplePath(G) ==
              /\ Cardinality({ p[i] : i \in DOMAIN p }) = Len(p)
              /\ \A i \in 1..(Len(p)-1) : <<p[i], p[i+1]>> \in G.edge}
 
+\* @supportedBy("TLC")
 AreConnectedIn(m, n, G) == 
   \E p \in SimplePath(G) : (p[1] = m) /\ (p[Len(p)] = n)
 
+\* @supportedBy("TLC")
 ConnectionsIn(G) ==
   \* Compute a Boolean matrix that indicates, for each pair of nodes,
   \* if there exists a path that links the two nodes. The computation,
@@ -56,9 +65,11 @@ ConnectionsIn(G) ==
                                    \/ Cu[m,u] /\ Cu[u,n]]
   IN  C[G.node]
 
+\* @supportedBy("TLC")
 IsStronglyConnected(G) == 
   \A m, n \in G.node : AreConnectedIn(m, n, G) 
 -----------------------------------------------------------------------------
+\* @supportedBy("TLC")
 IsTreeWithRoot(G, r) ==
   /\ IsDirectedGraph(G)
   /\ \A e \in G.edge : /\ e[1] # r

--- a/modules/HTML.tla
+++ b/modules/HTML.tla
@@ -5,6 +5,7 @@ LOCAL INSTANCE SequencesExt
 
 \***** Helpers
 
+\* @supportedBy("TLC")
 HTMLFill(string, args) ==
     (***********************************************************************)
     (* Do the sequence of replaces in args to the string.                  *)
@@ -15,6 +16,7 @@ HTMLFill(string, args) ==
     LET f(str, x) == ReplaceFirstSubSeq(x[2], x[1], str)
     IN FoldLeft(f, string, args)
 
+\* @supportedBy("TLC")
 LOCAL StringSeqToString(string_seq, separator) ==
     (***********************************************************************)
     (* Concatenates sequence of strings into one string.                   *)
@@ -27,6 +29,7 @@ LOCAL StringSeqToString(string_seq, separator) ==
 
 \***** Main Document
 
+\* @supportedBy("TLC")
 HTMLDocument(header, body, list_of_scripts) ==
     StringSeqToString(<<
         "<!DOCTYPE html>",
@@ -39,6 +42,7 @@ HTMLDocument(header, body, list_of_scripts) ==
 
 \***** Style Sheet
 
+\* @supportedBy("TLC")
 HTMLClass(classname, attribute_list) ==
     StringSeqToString(<<
         ReplaceFirstSubSeq(classname, "%classname%", "%classname% {"),
@@ -46,12 +50,14 @@ HTMLClass(classname, attribute_list) ==
         "}"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLAttribute(name, value) ==
     HTMLFill("%name%: %value%;", <<
         <<"%name%", name>>,
         <<"%value%", value>>
     >>)
 
+\* @supportedBy("TLC")
 HTMLDefaultStyle ==
     StringSeqToString(<<
         HTMLClass(".default_grid",<<
@@ -65,6 +71,7 @@ HTMLDefaultStyle ==
         >>)
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLStyleSheet(class_list) ==
     StringSeqToString(<<
         "<style type=\"text/css\">",
@@ -75,9 +82,11 @@ HTMLStyleSheet(class_list) ==
 
 \***** Script
 
+\* @supportedBy("TLC")
 HTMLScriptFile(name) ==
     HTMLFill("<script src=\"%name%\"></script>", << <<"%name%", name>>>> )
 
+\* @supportedBy("TLC")
 HTMLScript(children) ==
     StringSeqToString(<<
         "<script>",
@@ -87,10 +96,12 @@ HTMLScript(children) ==
 
 \***** Header
 
+\* @supportedBy("TLC")
 HTMLLink(name, type) ==
     HTMLFill("<link href=\"%name%\" rel=\"%type%\"/>",
         << <<"%name%", name>>, <<"%type%", type>> >> )
 
+\* @supportedBy("TLC")
 HTMLHeader(title, list_of_links, class_list) ==
     StringSeqToString(<<
         "<head>",
@@ -103,6 +114,7 @@ HTMLHeader(title, list_of_links, class_list) ==
 
 \***** Body
 
+\* @supportedBy("TLC")
 HTMLBody(body) ==
     StringSeqToString(<<
         "<body>",
@@ -110,6 +122,7 @@ HTMLBody(body) ==
         "</body>"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLFrame(id, children) ==
     StringSeqToString(<<
         ReplaceFirstSubSeq(id, "%id%", "<div id=\"%id%\">"),
@@ -117,6 +130,7 @@ HTMLFrame(id, children) ==
         "</div>"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLGridContainer(id, class_list, children) ==
     StringSeqToString(<<
         HTMLFill("<div id=\"%id%\" class=\"default_grid %class_list%\">",<<
@@ -127,6 +141,7 @@ HTMLGridContainer(id, class_list, children) ==
         "</div>"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLBox(id, class_list, size, children) ==
     StringSeqToString(<<
         HTMLFill("<div id=\"%id%\" class=\"default_box %class_list%\" style=\"%size%\">",<<
@@ -138,9 +153,11 @@ HTMLBox(id, class_list, size, children) ==
         "</div>"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLCircle(id, class_list, size, children)  ==
     HTMLBox(id, <<"default_circle">> \o class_list, size, children)
 
+\* @supportedBy("TLC")
 HTMLText(id, text) ==
     StringSeqToString(<<
         ReplaceFirstSubSeq(id, "%id%", "<span id=\"%id%\">"),
@@ -148,6 +165,7 @@ HTMLText(id, text) ==
         "</span>"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLSVG(id, viewBox, size, svgString) ==
     StringSeqToString(<<
         HTMLFill("<svg id=\"%id%\" viewBox=\"%viewBox%\" style=\"%size%\">",<<
@@ -161,15 +179,18 @@ HTMLSVG(id, viewBox, size, svgString) ==
 
 \***** Pre built
 
+\* @supportedBy("TLC")
 HTMLSize(width, height) ==
     StringSeqToString(<<
         HTMLAttribute("width", width),
         HTMLAttribute("height", height)
     >>, " ")
 
+\* @supportedBy("TLC")
 HTMLNewLine ==
     "<br>"
 
+\* @supportedBy("TLC")
 HTMLFlexCenterAttributes ==
     StringSeqToString(<<
         HTMLAttribute("display", "flex"),
@@ -177,20 +198,24 @@ HTMLFlexCenterAttributes ==
         HTMLAttribute("justify-content", "center")
     >>,"\n")
 
+\* @supportedBy("TLC")
 HTMLJSLineElems(fromID, destID) ==
     HTMLFill("document.getElementById(\"%id1%\"), document.getElementById(\"%id2%\")",
         << <<"%id1%", fromID>>, <<"%id2%", destID>> >> )
 
+\* @supportedBy("TLC")
 HTMLJSLine(fromID, destID, color, size) ==
     HTMLFill("new LeaderLine(%elems%, {color: '%color%', size: %size%})",
     << <<"%elems%", HTMLJSLineElems(fromID, destID)>>,
        <<"%color%", color>>, <<"%size%", size>> >> )
 
+\* @supportedBy("TLC")
 HTMLJSLineDash(fromID, destID, color, size) ==
     HTMLFill("new LeaderLine(%elems%,  {color: '%color%', size: %size%, dash: true})",
     << <<"%elems%", HTMLJSLineElems(fromID, destID)>>,
        <<"%color%", color>>, <<"%size%", size>> >> )
 
+\* @supportedBy("TLC")
 HTMLJSKeyListener(events) ==
     StringSeqToString(<<
         "window.onkeyup = function(event) {",
@@ -199,6 +224,7 @@ HTMLJSKeyListener(events) ==
         "}"
     >>, "\n")
 
+\* @supportedBy("TLC")
 HTMLJSNavigationKey(key, file) ==
     StringSeqToString(<<
         ReplaceFirstSubSeq(key, "%key%", "if(key == '%key%'){"),

--- a/modules/IOUtils.tla
+++ b/modules/IOUtils.tla
@@ -6,10 +6,13 @@ LOCAL INSTANCE Integers
   (* Imports the definitions from the modules, but doesn't export them.    *)
   (*************************************************************************)
 
+\* @supportedBy("TLC")
 IOSerialize(val, absoluteFilename, compress) == TRUE
 
+\* @supportedBy("TLC")
 IODeserialize(absoluteFilename, compressed) == CHOOSE val : TRUE
 
+\* @supportedBy("TLC")
 Serialize(value, dest, options) ==
   (*******************************************************************************)
   (* value: TLA+ value to be serialized.                                         *)
@@ -20,6 +23,7 @@ Serialize(value, dest, options) ==
   (*******************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
+\* @supportedBy("TLC")
 Deserialize(src, options) ==
   (*******************************************************************************)
   (* src: Destination to serialize to such as a file or URL.                     *)
@@ -31,6 +35,7 @@ Deserialize(src, options) ==
 
 ----------------------------------------------------------------------------
 
+\* @supportedBy("TLC")
 IOExec(command) ==
   (*******************************************************************************)
   (* Spawns the given command as a sub-process of TLC.  The sequence of sequence *)
@@ -42,6 +47,7 @@ IOExec(command) ==
   (*******************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
+\* @supportedBy("TLC")
 IOEnvExec(env, command) ==
   (*******************************************************************************)
   (* See IOExec                                                                  *)
@@ -50,6 +56,7 @@ IOEnvExec(env, command) ==
   (*******************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
+\* @supportedBy("TLC")
 IOExecTemplate(commandTemplate, parameters) ==
   (*************************************************************************)
   (* Spawns the given printf-style command as a sub-process of TLC.  The   *)
@@ -61,6 +68,7 @@ IOExecTemplate(commandTemplate, parameters) ==
   (*************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
+\* @supportedBy("TLC")
 IOEnvExecTemplate(env, commandTemplate, parameters) ==
   (*******************************************************************************)
   (* See IOExecTemplate                                                          *)
@@ -69,12 +77,14 @@ IOEnvExecTemplate(env, commandTemplate, parameters) ==
   (*******************************************************************************)
   CHOOSE r \in [exitValue : Int, stdout : STRING, stderr : STRING] : TRUE
 
+\* @supportedBy("TLC")
 IOEnv ==
   (*************************************************************************)
   (* The process' environment variables.                                   *)
   (*************************************************************************)
   CHOOSE r \in [STRING -> STRING] : TRUE
 
+\* @supportedBy("TLC")
 atoi(str) ==
   (*************************************************************************)
   (* Assuming the environment variable  SomeEnvVar  is set to  42,         *)

--- a/modules/Json.tla
+++ b/modules/Json.tla
@@ -9,12 +9,15 @@ LOCAL INSTANCE TLC
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC")
 LOCAL IsSequence(F, D) == TRUE \/ FALSE
 
+\* @supportedBy("TLC")
 LOCAL ToJsonKeyValue(F, d) ==
   ToString(ToString(d)) \o ":" \o ToString(F[d])
 
 RECURSIVE ToJsonObjectString(_,_)
+\* @supportedBy("TLC")
 LOCAL ToJsonObjectString(F, D) == \* LOCAL just a hint for humans.
   LET d == CHOOSE d \in D: TRUE
   IN IF D = DOMAIN F
@@ -26,6 +29,7 @@ LOCAL ToJsonObjectString(F, D) == \* LOCAL just a hint for humans.
                                           ELSE ToJsonObjectString(F, D \ {d})
 
 RECURSIVE ToJsonArrayString(_,_)
+\* @supportedBy("TLC")
 LOCAL ToJsonArrayString(F, D) == \* LOCAL just a hint for humans.
   LET d == CHOOSE d \in D: TRUE
   IN IF D = DOMAIN F
@@ -37,12 +41,14 @@ LOCAL ToJsonArrayString(F, D) == \* LOCAL just a hint for humans.
                                     ELSE ToJsonArrayString(F, D \ {d})
 
 RECURSIVE ToJsonString(_,_)
+\* @supportedBy("TLC")
 LOCAL ToJsonString(F, D) == \* LOCAL just a hint for humans.
   IF IsFiniteSet(F) \/ IsSequence(F, D) THEN
     ToJsonArrayString(F, D)
   ELSE
     ToJsonObjectString(F, D)
 
+\* @supportedBy("TLC")
 ToJson(value) ==
   (*************************************************************************)
   (* Converts the given value to a JSON string. Records are converted to   *)
@@ -54,6 +60,7 @@ ToJson(value) ==
   ELSE
     ToJsonString(value, DOMAIN value)
 
+\* @supportedBy("TLC")
 ToJsonArray(value) ==
   (*************************************************************************)
   (* Converts the given tuple value to a JSON array.                       *)
@@ -63,6 +70,7 @@ ToJsonArray(value) ==
   ELSE
     ToJsonArrayString(value, DOMAIN value)
 
+\* @supportedBy("TLC")
 ToJsonObject(value) ==
   (*************************************************************************)
   (* Converts the given tuple value to a JSON object.                      *)
@@ -72,6 +80,7 @@ ToJsonObject(value) ==
   ELSE
     ToJsonObjectString(value, DOMAIN value)
 
+\* @supportedBy("TLC")
 JsonSerialize(absoluteFilename, value) ==
   (*************************************************************************)
   (* Serializes a tuple of values to the given file as (plain) JSON.       *)
@@ -79,6 +88,7 @@ JsonSerialize(absoluteFilename, value) ==
   (*************************************************************************)
   TRUE
 
+\* @supportedBy("TLC")
 JsonDeserialize(absoluteFilename) ==
   (*************************************************************************)
   (* Deserializes JSON values from the given file. JSON objects will be    *)
@@ -86,6 +96,7 @@ JsonDeserialize(absoluteFilename) ==
   (*************************************************************************)
   CHOOSE val : TRUE
 
+\* @supportedBy("TLC")
 ndJsonSerialize(absoluteFilename, value) ==
   (*************************************************************************)
   (* Serializes a tuple of values to the given file as newline delimited   *)
@@ -94,6 +105,7 @@ ndJsonSerialize(absoluteFilename, value) ==
   (*************************************************************************)
   TRUE
 
+\* @supportedBy("TLC")
 ndJsonDeserialize(absoluteFilename) ==
   (*************************************************************************)
   (* Deserializes JSON values from the given file. JSON values must be     *)

--- a/modules/Relation.tla
+++ b/modules/Relation.tla
@@ -10,31 +10,37 @@ LOCAL INSTANCE FiniteSets
 (***************************************************************************)
 (* Is the relation R reflexive over S?                                     *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 IsReflexive(R, S) == \A x \in S : R[x,x]
 
 (***************************************************************************)
 (* Is the relation R irreflexive over set S?                               *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 IsIrreflexive(R, S) == \A x \in S : ~ R[x,x]
 
 (***************************************************************************)
 (* Is the relation R symmetric over set S?                                 *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 IsSymmetric(R, S) == \A x,y \in S : R[x,y] <=> R[y,x]
 
 (***************************************************************************)
 (* Is the relation R asymmetric over set S?                                *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 IsAsymmetric(R, S) == \A x,y \in S : ~(R[x,y] /\ R[y,x])
 
 (***************************************************************************)
 (* Is the relation R transitive over set S?                                *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 IsTransitive(R, S) == \A x,y,z \in S : R[x,y] /\ R[y,z] => R[x,z]
 
 (***************************************************************************)
 (* Compute the transitive closure of relation R over set S.                *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 TransitiveClosure(R, S) ==
   LET N == Cardinality(S)
       trcl[n \in Nat] == 
@@ -46,6 +52,7 @@ TransitiveClosure(R, S) ==
 (***************************************************************************)
 (* Compute the reflexive transitive closure of relation R over set S.      *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 ReflexiveTransitiveClosure(R, S) ==
   LET trcl == TransitiveClosure(R,S)
   IN  [x,y \in S |-> x=y \/ trcl[x,y]]
@@ -54,6 +61,7 @@ ReflexiveTransitiveClosure(R, S) ==
 (* Is the relation R connected over set S, i.e. does there exist a path    *)
 (* between two arbitrary elements of S?                                    *)
 (***************************************************************************)
+\* @supportedBy("TLC")
 IsConnected(R, S) ==
   LET rtrcl == ReflexiveTransitiveClosure(R,S)
   IN  \A x,y \in S : rtrcl[x,y]

--- a/modules/SVG.tla
+++ b/modules/SVG.tla
@@ -9,6 +9,7 @@ LOCAL INSTANCE FiniteSets
 (* Helper Operators                                                           *)
 (******************************************************************************)
 
+\* @supportedBy("TLC")
 LOCAL Merge(r1, r2) == 
     (**************************************************************************)
     (* Merge two records.                                                     *)
@@ -19,6 +20,7 @@ LOCAL Merge(r1, r2) ==
         D2 == DOMAIN r2 IN
     [k \in (D1 \cup D2) |-> IF k \in D1 THEN r1[k] ELSE r2[k]]
 
+\* @supportedBy("TLC")
 LOCAL SVGElem(_name, _attrs, _children, _innerText) == 
     (**************************************************************************)
     (* SVG element constructor.                                               *)
@@ -57,6 +59,7 @@ LOCAL SVGElem(_name, _attrs, _children, _innerText) ==
 (*                                                                            *)
 (******************************************************************************)
 
+\* @supportedBy("TLC")
 Line(x1, y1, x2, y2, attrs) == 
     (**************************************************************************)
     (* Line element.  'x1', 'y1', 'x2', and 'y2' should be given as integers. *)
@@ -67,6 +70,7 @@ Line(x1, y1, x2, y2, attrs) ==
                      y2 |-> ToString(y2)] IN
     SVGElem("line", Merge(svgAttrs, attrs), <<>>, "")
 
+\* @supportedBy("TLC")
 Circle(cx, cy, r, attrs) == 
     (**************************************************************************)
     (* Circle element. 'cx', 'cy', and 'r' should be given as integers.       *)
@@ -76,6 +80,7 @@ Circle(cx, cy, r, attrs) ==
                      r  |-> ToString(r)] IN
     SVGElem("circle", Merge(svgAttrs, attrs), <<>>, "")
 
+\* @supportedBy("TLC")
 Rect(x, y, w, h, attrs) == 
     (**************************************************************************)
     (* Rectangle element.  'x', 'y', 'w', and 'h' should be given as          *)
@@ -87,6 +92,7 @@ Rect(x, y, w, h, attrs) ==
                      height |-> ToString(h)] IN
     SVGElem("rect", Merge(svgAttrs, attrs), <<>>, "")
 
+\* @supportedBy("TLC")
 Text(x, y, text, attrs) == 
     (**************************************************************************)
     (* Text element.'x' and 'y' should be given as integers, and 'text' given *)
@@ -96,6 +102,7 @@ Text(x, y, text, attrs) ==
                      y |-> ToString(y)] IN
     SVGElem("text", Merge(svgAttrs, attrs), <<>>, text) 
 
+\* @supportedBy("TLC")
 Group(children, attrs) == 
     (**************************************************************************)
     (* Group element.  'children' is a sequence of elements that will be      *)
@@ -103,6 +110,7 @@ Group(children, attrs) ==
     (**************************************************************************)
     SVGElem("g", attrs, children, "")
 
+\* @supportedBy("TLC")
 Svg(children, attrs) == 
     (**************************************************************************)
     (* Svg container.  'children' is a sequence of elements that will be      *)
@@ -110,6 +118,7 @@ Svg(children, attrs) ==
     (**************************************************************************)
     SVGElem("svg", attrs, children, "")
 
+\* @supportedBy("TLC")
 SVGElemToString(elem) == 
     (**************************************************************************)
     (* Convert an SVG element record into its string representation.          *)
@@ -124,6 +133,7 @@ SVGElemToString(elem) ==
 
 -------------------------------------------------------------------------------
 
+\* @supportedBy("TLC")
 NodeOfRingNetwork(cx, cy, r, n, m) ==
     (**************************************************************************)
     (* Equals the Cartesian coordinates of the n-th of m nodes in a ring      *)
@@ -155,6 +165,7 @@ NodeOfRingNetwork(cx, cy, r, n, m) ==
     (**************************************************************************)
     [ x |-> 0, y |-> 0 ]
 
+\* @supportedBy("TLC")
 NodesOfDirectedMultiGraph(nodes, edges, options) ==
     (**************************************************************************)
     (* Example to layout a graph with the given Nodes and Edges:              *)
@@ -174,6 +185,7 @@ NodesOfDirectedMultiGraph(nodes, edges, options) ==
     (**************************************************************************)
     CHOOSE f \in [ nodes -> [x: Int, y: Int] ]: TRUE
 
+\* @supportedBy("TLC")
 PointOnLine(from, to, segment) ==
     [x |-> from.x + ((to.x - from.x) \div segment), 
      y |-> from.y + ((to.y - from.y) \div segment)]

--- a/modules/SequencesExt.tla
+++ b/modules/SequencesExt.tla
@@ -12,6 +12,7 @@ LOCAL INSTANCE TLC
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 ToSet(s) ==
   (*************************************************************************)
   (* The image of the given sequence s. Cardinality(ToSet(s)) <= Len(s)    *)
@@ -19,6 +20,7 @@ ToSet(s) ==
   (*************************************************************************)
   { s[i] : i \in DOMAIN s }
 
+\* @supportedBy("TLC,Apalache")
 SetToSeq(S) == 
   (**************************************************************************)
   (* Convert a set to some sequence that contains all the elements of the   *)
@@ -26,6 +28,7 @@ SetToSeq(S) ==
   (**************************************************************************)
   CHOOSE f \in [1..Cardinality(S) -> S] : IsInjective(f)
 
+\* @supportedBy("TLC,Apalache")
 SetToSeqs(S) == 
   (**************************************************************************)
   (* Convert the set S to a set containing all sequences containing the     *)
@@ -37,6 +40,7 @@ SetToSeqs(S) ==
   LET D == 1..Cardinality(S)
   IN { f \in [D -> S] : \A i,j \in D : i # j => f[i] # f[j] }
 
+\* @supportedBy("TLC,Apalache")
 SetToSortSeq(S, op(_,_)) ==
   (**************************************************************************)
   (* Convert a set to a sorted sequence that contains all the elements of   *)
@@ -46,6 +50,7 @@ SetToSortSeq(S, op(_,_)) ==
   \* because this variant works efficiently without a dedicated TLC override.
   SortSeq(SetToSeq(S), op)
 
+\* @supportedBy("TLC")
 SetToAllKPermutations(S) ==
   (**************************************************************************)
   (* Convert the set S to a set containing all k-permutations of elements   *)
@@ -58,12 +63,14 @@ SetToAllKPermutations(S) ==
   (**************************************************************************)
   UNION { SetToSeqs(s) : s \in SUBSET S  }
 
+\* @supportedBy("TLC")
 TupleOf(set, n) == 
   (***************************************************************************)
   (* TupleOf(s, 3) = s \X s \X s                                             *)
   (***************************************************************************)
   [1..n -> set]
 
+\* @supportedBy("TLC")
 SeqOf(set, n) == 
   (***************************************************************************)
   (* All sequences up to length n with all elements in set.  Includes empty  *)
@@ -71,6 +78,7 @@ SeqOf(set, n) ==
   (***************************************************************************)
   UNION {[1..m -> set] : m \in 0..n}
 
+\* @supportedBy("TLC")
 BoundedSeq(S, n) ==
   (***************************************************************************)
   (* An alias for SeqOf to make the connection to Sequences!Seq, which is    *)
@@ -80,12 +88,14 @@ BoundedSeq(S, n) ==
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 Contains(s, e) ==
   (**************************************************************************)
   (* TRUE iff the element e \in ToSet(s).                                   *)
   (**************************************************************************)
   \E i \in 1..Len(s) : s[i] = e
 
+\* @supportedBy("TLC,Apalache")
 Reverse(s) ==
   (**************************************************************************)
   (* Reverse the given sequence s:  Let l be Len(s) (length of s).          *)
@@ -93,12 +103,14 @@ Reverse(s) ==
   (**************************************************************************)
   [ i \in 1..Len(s) |-> s[(Len(s) - i) + 1] ]
 
+\* @supportedBy("TLC,Apalache")
 Remove(s, e) ==
     (************************************************************************)
     (* The sequence s with e removed or s iff e \notin Range(s)             *)
     (************************************************************************)
     SelectSeq(s, LAMBDA t: t # e)
 
+\* @supportedBy("TLC,Apalache")
 ReplaceAll(s, old, new) ==
   (*************************************************************************)
   (* Equals the sequence s except that all occurrences of element old are  *)
@@ -112,6 +124,7 @@ ReplaceAll(s, old, new) ==
 \* from the TLAPS module SequencesTheorems.tla as of 10/14/2019.  The original
 \* comments have been partially rewritten.
 
+\* @supportedBy("TLC,Apalache")
 InsertAt(s, i, e) ==
   (**************************************************************************)
   (* Inserts element e at the position i moving the original element to i+1 *)
@@ -123,12 +136,14 @@ InsertAt(s, i, e) ==
   (**************************************************************************)
   SubSeq(s, 1, i-1) \o <<e>> \o SubSeq(s, i, Len(s))
 
+\* @supportedBy("TLC,Apalache")
 ReplaceAt(s, i, e) ==
   (**************************************************************************)
   (* Replaces the element at position i with the element e.                 *)
   (**************************************************************************)
   [s EXCEPT ![i] = e]
   
+\* @supportedBy("TLC,Apalache")
 RemoveAt(s, i) == 
   (**************************************************************************)
   (* Replaces the element at position i shortening the length of s by one.  *)
@@ -137,18 +152,21 @@ RemoveAt(s, i) ==
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 Cons(elt, seq) == 
     (************************************************************************)
     (* Cons prepends an element at the beginning of a sequence.             *)
     (************************************************************************)
     <<elt>> \o seq
 
+\* @supportedBy("TLC,Apalache")
 Front(s) == 
   (**************************************************************************)
   (* The sequence formed by removing its last element.                      *)
   (**************************************************************************)
   SubSeq(s, 1, Len(s)-1)
 
+\* @supportedBy("TLC,Apalache")
 Last(s) ==
   (**************************************************************************)
   (* The last element of the sequence.                                      *)
@@ -157,6 +175,7 @@ Last(s) ==
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 IsPrefix(s, t) ==
   (**************************************************************************)
   (* TRUE iff the sequence s is a prefix of the sequence t, s.t.            *)
@@ -165,12 +184,14 @@ IsPrefix(s, t) ==
   (**************************************************************************)
   Len(s) <= Len(t) /\ SubSeq(s, 1, Len(s)) = SubSeq(t, 1, Len(s))
 
+\* @supportedBy("TLC,Apalache")
 IsStrictPrefix(s,t) ==
   (**************************************************************************)
   (* TRUE iff the sequence s is a prefix of the sequence t and s # t        *)
   (**************************************************************************)
   IsPrefix(s, t) /\ s # t
 
+\* @supportedBy("TLC,Apalache")
 IsSuffix(s, t) ==
   (**************************************************************************)
   (* TRUE iff the sequence s is a suffix of the sequence t, s.t.            *)
@@ -179,6 +200,7 @@ IsSuffix(s, t) ==
   (**************************************************************************)
   IsPrefix(Reverse(s), Reverse(t))
 
+\* @supportedBy("TLC,Apalache")
 IsStrictSuffix(s, t) ==
   (**************************************************************************)
   (* TRUE iff the sequence s is a suffix of the sequence t and s # t        *)
@@ -187,12 +209,14 @@ IsStrictSuffix(s, t) ==
   
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 Prefixes(s) ==
   (**************************************************************************)
   (* The set of prefixes of the sequence s, including the empty sequence.   *)
   (**************************************************************************)
   { SubSeq(s, 1, l) : l \in 0..Len(s) } \* 0.. for <<>>
 
+\* @supportedBy("TLC,Apalache")
 CommonPrefixes(S) ==
   (**************************************************************************)
   (* The set of all sequences that are prefixes of the set of sequences S.  *)
@@ -200,6 +224,7 @@ CommonPrefixes(S) ==
   LET P == UNION { Prefixes(seq) : seq \in S }
   IN { prefix \in P : \A t \in S: IsPrefix(prefix, t) }
 
+\* @supportedBy("TLC,Apalache")
 LongestCommonPrefix(S) ==
   (**************************************************************************)
   (* The longest common prefix of the sequences in the set S.               *)
@@ -210,6 +235,7 @@ LongestCommonPrefix(S) ==
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 SeqMod(a, b) == 
   (***************************************************************************)
   (*   Range(a % b) = 0..b-1, but DOMAIN seq = 1..Len(seq).                  *)
@@ -219,6 +245,7 @@ SeqMod(a, b) ==
   IF a % b = 0 THEN b ELSE a % b
 
 
+\* @supportedBy("TLC,Apalache")
 FoldSeq(op(_, _), base, seq) == 
   (***************************************************************************)
   (* An alias of FoldFunction that op on all elements of seq an arbitrary    *)
@@ -233,6 +260,7 @@ FoldSeq(op(_, _), base, seq) ==
   (***************************************************************************)
   FoldFunction(op, base, seq)
 
+\* @supportedBy("TLC,Apalache")
 FoldLeft(op(_, _), base, seq) == 
   (***************************************************************************)
   (* FoldLeft folds op on all elements of seq from left to right, starting   *)
@@ -249,6 +277,7 @@ FoldLeft(op(_, _), base, seq) ==
                  LAMBDA S : Max(S),
                  DOMAIN seq)
 
+\* @supportedBy("TLC,Apalache")
 FoldRight(op(_, _), seq, base) == 
   (***************************************************************************)
   (* FoldRight folds op on all elements of seq from right to left, starting  *)
@@ -267,6 +296,7 @@ FoldRight(op(_, _), seq, base) ==
 
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC,Apalache")
 FlattenSeq(seqs) ==
   (**************************************************************************)
   (* A sequence of all elements from all sequences in the sequence  seqs  . *)
@@ -283,6 +313,7 @@ FlattenSeq(seqs) ==
         IF i = 1 THEN seqs[i] ELSE flatten[i-1] \o seqs[i]
     IN flatten[Len(seqs)]
 
+\* @supportedBy("TLC,Apalache")
 Zip(s, t) ==
   (**************************************************************************)
   (* A sequence where the i-th tuple contains the i-th element of  s  and   *)
@@ -300,6 +331,7 @@ Zip(s, t) ==
     [] Len(s) = Len(t) /\ Len(s) = 0 -> << >>
     \* error "Zip: sequences must have same length"
 
+\* @supportedBy("TLC")
 Interleave(s, t) ==
   (**************************************************************************)
   (* A sequence where the i-th tuple contains the i-th element of  s  and   *)
@@ -320,6 +352,7 @@ Interleave(s, t) ==
     [] Len(s) = Len(t) /\ Len(s) = 0 -> << <<>>, <<>> >>
     \* error "Interleave: sequences must have same length"
 
+\* @supportedBy("TLC,Apalache")
 SubSeqs(s) ==
   (**************************************************************************)
   (* The set of all subsequences of the sequence  s  .  Note that the empty *)
@@ -328,6 +361,7 @@ SubSeqs(s) ==
   { SubSeq(s, i+1, j) : i, j \in 0..Len(s) }
 
 
+\* @supportedBy("TLC,Apalache")
 IndexFirstSubSeq(s, t) ==
   (**************************************************************************)
   (* The (1-based) index of the beginning of the subsequence  s  of the     *)
@@ -340,6 +374,7 @@ IndexFirstSubSeq(s, t) ==
                 /\ \A j \in 0..i-1 : s \notin SubSeqs(SubSeq(t, 1, j))
   IN last - (Len(s) - 1)
 
+\* @supportedBy("TLC,Apalache")
 ReplaceSubSeqAt(i, r, s, t) ==
   (**************************************************************************)
   (* The sequence  t  with its subsequence  s  at position  i  replaced by  *)
@@ -349,6 +384,7 @@ ReplaceSubSeqAt(i, r, s, t) ==
       suffix == SubSeq(t, i + Len(s), Len(t))
   IN prefix \o r \o suffix 
 
+\* @supportedBy("TLC,Apalache")
 ReplaceFirstSubSeq(r, s, t) ==
   (**************************************************************************)
   (* The sequence  t  with its subsequence  s  replaced by the sequence  r  *)
@@ -357,6 +393,7 @@ ReplaceFirstSubSeq(r, s, t) ==
   THEN ReplaceSubSeqAt(IndexFirstSubSeq(s, t), r, s, t)
   ELSE t
 
+\* @supportedBy("TLC")
 ReplaceAllSubSeqs(r, s, t) ==
   (**************************************************************************)
   (* The sequence  t  with all subsequences  s  replaced by the sequence  r *)

--- a/modules/ShiViz.tla
+++ b/modules/ShiViz.tla
@@ -23,6 +23,7 @@ INSTANCE Toolbox
 \* whereas the CHOOSE evalutes for states n and n + 1.
 \* This difference is most easily observed by looking
 \* at off-by-one difference of the initial state.
+\* @supportedBy("TLC")
 LOCAL FnHost ==
     LET host[i \in DOMAIN _TETrace] ==
         (*************************************************************************)
@@ -36,19 +37,23 @@ LOCAL FnHost ==
                             _TETrace[i-1].pc[p] # _TETrace[i].pc[p]
     IN TLCEval(host)
 
+\* @supportedBy("TLC")
 Host == FnHost[_TEPosition]
     
 -----------------------------------------------------------------------------
 
+\* @supportedBy("TLC")
 LOCAL clock(n) == 
    IF n = 1 THEN [p \in DOMAIN _TETrace[n].pc |-> 0] \* In the init state, all clocks are 0.
    ELSE [p \in DOMAIN _TETrace[n].pc |-> IF p = FnHost[n] 
                                     THEN 1
                                     ELSE 0]
 
+\* @supportedBy("TLC")
 LOCAL sum(F, G) == 
    [d \in DOMAIN F |-> F[d] + G[d]]
 
+\* @supportedBy("TLC")
 LOCAL FnClock == 
     LET vclock[i \in DOMAIN _TETrace] == 
         IF i = 1
@@ -56,6 +61,7 @@ LOCAL FnClock ==
         ELSE sum(TLCEval(vclock[i-1]), clock(i))
     IN TLCEval(vclock)
 
+\* @supportedBy("TLC")
 Clock ==
    (*************************************************************************)
    (* The pc variable formatted as a Json object as required by ShiViz.     *)


### PR DESCRIPTION
This PR introduces the annotation `@supportedBy("TLC")` or `@supportedBy("TLC,Apalache")` in front of all operators, to document which operators are supported only by TLC and which operators are supported by TLC and Apalache.