### PR TITLE
Function restriction based on a test predicate

### DIFF
--- a/modules/Functions.tla
+++ b/modules/Functions.tla
@@ -19,10 +19,10 @@ Restrict(f,S) == [ x \in S |-> f[x] ]
 (*                                                                         *)
 (* Example:                                                                *)
 (*   (LET f == (0 :> "a" @@ 1 :> "b" @@ 2 :> "c")                          *)
-(*    IN  SelectDomain(f, LAMBDA x : x \in {0,2}))                         *)
+(*    IN  RestrictDomain(f, LAMBDA x : x \in {0,2}))                       *)
 (*   = (0 :> "a" @@ 2 :> "c")                                              *)
 (***************************************************************************)
-SelectDomain(f, Test(_)) == Restrict(f, {x \in DOMAIN f : Test(x)})
+RestrictDomain(f, Test(_)) == Restrict(f, {x \in DOMAIN f : Test(x)})
 
 (***************************************************************************)
 (* Restriction of a function to the subset of its domain for which the     *)
@@ -30,18 +30,18 @@ SelectDomain(f, Test(_)) == Restrict(f, {x \in DOMAIN f : Test(x)})
 (*                                                                         *)
 (* Example:                                                                *)
 (*   (LET f == ("a" :> 0 @@ "b" :> 1 @@ "c" :> 2)                          *)
-(*    IN  SelectValues(f, LAMBDA y : y \in {0,2}))                         *)
+(*    IN  RestrictValues(f, LAMBDA y : y \in {0,2}))                       *)
 (*   = ("a" :> 0 @@ "b" :> 2)                                              *)
 (*                                                                         *)
 (* This is similar to the operator SelectSeq from the standard Sequences   *)
 (* module and related to standard "filter" functions in functional         *)
 (* programming. However, SelectSeq produces sequences, whereas             *)
-(* SelectValues will in general not. For example,                          *)
+(* RestrictValues will in general not. For example,                        *)
 (*                                                                         *)
-(*   SelectValues([0,1,2], LAMBDA y : y \in {0,2})                         *)
+(*   RestrictValues([0,1,2], LAMBDA y : y \in {0,2})                       *)
 (*   = (1 :> 0 @@ 3 :> 2)                                                  *)
 (***************************************************************************)
-SelectValues(f, Test(_)) ==
+RestrictValues(f, Test(_)) ==
   LET S == {x \in DOMAIN f : Test(f[x])}
   IN  Restrict(f, S)
 
@@ -142,7 +142,7 @@ FoldFunctionOnSet(op(_,_), base, fun, indices) ==
 
 =============================================================================
 \* Modification History
-\* Last modified Sun Oct 30 10:13:23 CET 2022 by merz
+\* Last modified Tue Nov 01 08:46:11 CET 2022 by merz
 \* Last modified Mon Apr 05 03:25:53 CEST 2021 by marty
 \* Last modified Wed Jun 05 12:14:19 CEST 2013 by bhargav
 \* Last modified Fri May 03 12:55:35 PDT 2013 by tomr

--- a/modules/Functions.tla
+++ b/modules/Functions.tla
@@ -30,18 +30,18 @@ SelectDomain(f, Test(_)) == Restrict(f, {x \in DOMAIN f : Test(x)})
 (*                                                                         *)
 (* Example:                                                                *)
 (*   (LET f == ("a" :> 0 @@ "b" :> 1 @@ "c" :> 2)                          *)
-(*    IN  SelectValue(f, LAMBDA y : y \in {0,2}))                          *)
+(*    IN  SelectValues(f, LAMBDA y : y \in {0,2}))                         *)
 (*   = ("a" :> 0 @@ "b" :> 2)                                              *)
 (*                                                                         *)
 (* This is similar to the operator SelectSeq from the standard Sequences   *)
 (* module and related to standard "filter" functions in functional         *)
-(* programming. However, SelectSeq produces sequences, whereas SelectValue *)
-(* will in general not. For example,                                       *)
+(* programming. However, SelectSeq produces sequences, whereas             *)
+(* SelectValues will in general not. For example,                          *)
 (*                                                                         *)
-(*   SelectValue([0,1,2], LAMBDA y : y \in {0,2})                          *)
+(*   SelectValues([0,1,2], LAMBDA y : y \in {0,2})                         *)
 (*   = (1 :> 0 @@ 3 :> 2)                                                  *)
 (***************************************************************************)
-SelectValue(f, Test(_)) ==
+SelectValues(f, Test(_)) ==
   LET S == {x \in DOMAIN f : Test(f[x])}
   IN  Restrict(f, S)
 
@@ -142,7 +142,7 @@ FoldFunctionOnSet(op(_,_), base, fun, indices) ==
 
 =============================================================================
 \* Modification History
-\* Last modified Sun Oct 30 09:52:56 CET 2022 by merz
+\* Last modified Sun Oct 30 10:13:23 CET 2022 by merz
 \* Last modified Mon Apr 05 03:25:53 CEST 2021 by marty
 \* Last modified Wed Jun 05 12:14:19 CEST 2013 by bhargav
 \* Last modified Fri May 03 12:55:35 PDT 2013 by tomr

--- a/modules/Functions.tla
+++ b/modules/Functions.tla
@@ -14,6 +14,38 @@ LOCAL INSTANCE Folds
 Restrict(f,S) == [ x \in S |-> f[x] ]
 
 (***************************************************************************)
+(* Restriction of a function to the subset of its domain satisfying a      *)
+(* test predicate.                                                         *)
+(*                                                                         *)
+(* Example:                                                                *)
+(*   (LET f == (0 :> "a" @@ 1 :> "b" @@ 2 :> "c")                          *)
+(*    IN  SelectDomain(f, LAMBDA x : x \in {0,2}))                         *)
+(*   = (0 :> "a" @@ 2 :> "c")                                              *)
+(***************************************************************************)
+SelectDomain(f, Test(_)) == Restrict(f, {x \in DOMAIN f : Test(x)})
+
+(***************************************************************************)
+(* Restriction of a function to the subset of its domain for which the     *)
+(* function values satisfy a test predicate.                               *)
+(*                                                                         *)
+(* Example:                                                                *)
+(*   (LET f == ("a" :> 0 @@ "b" :> 1 @@ "c" :> 2)                          *)
+(*    IN  SelectValue(f, LAMBDA y : y \in {0,2}))                          *)
+(*   = ("a" :> 0 @@ "b" :> 2)                                              *)
+(*                                                                         *)
+(* This is similar to the operator SelectSeq from the standard Sequences   *)
+(* module and related to standard "filter" functions in functional         *)
+(* programming. However, SelectSeq produces sequences, whereas SelectValue *)
+(* will in general not. For example,                                       *)
+(*                                                                         *)
+(*   SelectValue([0,1,2], LAMBDA y : y \in {0,2})                          *)
+(*   = (1 :> 0 @@ 3 :> 2)                                                  *)
+(***************************************************************************)
+SelectValue(f, Test(_)) ==
+  LET S == {x \in DOMAIN f : Test(f[x])}
+  IN  Restrict(f, S)
+
+(***************************************************************************)
 (* Range of a function.                                                    *)
 (* Note: The image of a set under function f can be defined as             *)
 (*       Range(Restrict(f,S)).                                             *)
@@ -110,8 +142,8 @@ FoldFunctionOnSet(op(_,_), base, fun, indices) ==
 
 =============================================================================
 \* Modification History
+\* Last modified Sun Oct 30 09:52:56 CET 2022 by merz
 \* Last modified Mon Apr 05 03:25:53 CEST 2021 by marty
-\* Last modified Sun Dec 27 09:38:06 CET 2020 by merz
 \* Last modified Wed Jun 05 12:14:19 CEST 2013 by bhargav
 \* Last modified Fri May 03 12:55:35 PDT 2013 by tomr
 \* Created Thu Apr 11 10:30:48 PDT 2013 by tomr

--- a/tests/FunctionsTests.tla
+++ b/tests/FunctionsTests.tla
@@ -3,6 +3,12 @@ EXTENDS Functions, Naturals, TLC, TLCExt, FiniteSets, Sequences
 
 ASSUME LET T == INSTANCE TLC IN T!PrintT("FunctionsTests")
 
+ASSUME SelectDomain([x \in 0 .. 9 |-> x*x], LAMBDA x : x % 2 = 0)
+       = (0 :> 0 @@ 2 :> 4 @@ 4 :> 16 @@ 6 :> 36 @@ 8 :> 64)
+
+ASSUME SelectValues([x \in 0 .. 9 |-> x*x], LAMBDA y : y % 4 = 0)
+       = (0 :> 0 @@ 2 :> 4 @@ 4 :> 16 @@ 6 :> 36 @@ 8 :> 64)
+
 ASSUME(IsInjective(<<>>))
 ASSUME(IsInjective(<<1>>))
 ASSUME(IsInjective(<<1,2,3>>))

--- a/tests/FunctionsTests.tla
+++ b/tests/FunctionsTests.tla
@@ -3,10 +3,10 @@ EXTENDS Functions, Naturals, TLC, TLCExt, FiniteSets, Sequences
 
 ASSUME LET T == INSTANCE TLC IN T!PrintT("FunctionsTests")
 
-ASSUME SelectDomain([x \in 0 .. 9 |-> x*x], LAMBDA x : x % 2 = 0)
+ASSUME RestrictDomain([x \in 0 .. 9 |-> x*x], LAMBDA x : x % 2 = 0)
        = (0 :> 0 @@ 2 :> 4 @@ 4 :> 16 @@ 6 :> 36 @@ 8 :> 64)
 
-ASSUME SelectValues([x \in 0 .. 9 |-> x*x], LAMBDA y : y % 4 = 0)
+ASSUME RestrictValues([x \in 0 .. 9 |-> x*x], LAMBDA y : y % 4 = 0)
        = (0 :> 0 @@ 2 :> 4 @@ 4 :> 16 @@ 6 :> 36 @@ 8 :> 64)
 
 ASSUME(IsInjective(<<>>))


### PR DESCRIPTION
In response to issue #81: added two operators for restricting a function based on a test predicate applied to the arguments or the result values of the function. I chose the names SelectDomain and SelectValues, to align with the SelectSeq operator from the standard Sequences module.