### PR TITLE
Update usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,16 @@ You must be running [Java 9 or higher](https://github.com/tlaplus/CommunityModul
 
 Just copy & paste the snippet, the operators, or the set of modules you are interested in.
 
-Alternatively, you can download a [library archive](https://github.com/tlaplus/CommunityModules/releases) and add it to TLC's or the Toolbox's *TLA+ library path*.  The advantage of the library archive is that TLC will evaluate an operator faster if the operator comes with a (Java) implementation (see e.g. [SequencesExt.Java](https://github.com/tlaplus/CommunityModules/blob/master/modules/tlc2/overrides/SequencesExt.java)).  Run TLC with ```-DTLA-Library=/path/to/lib/archive``` or add the library archive to the Toolbox (```File > Preferences > TLA+ Preferences > TLA+ library path locations```).  The latest release is at the stable URL https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules.jar.
+Alternatively, clone this repository and pass ```-DTLA-Library=/path/to/CommunityModules/modules``` when running TLC.
+
+Another option is to download a [library archive](https://github.com/tlaplus/CommunityModules/releases) and add it to TLC's or the Toolbox's *TLA+ library path*. The advantage of doing this is that TLC will evaluate an operator faster if the operator comes with a Java implementation (see e.g. [SequencesExt.Java](https://github.com/tlaplus/CommunityModules/blob/master/modules/tlc2/overrides/SequencesExt.java)). The latest release is at the stable URL https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules.jar.
+
+If you are using the Toolbox, add the library archive under `File > Preferences > TLA+ Preferences > TLA+ library path locations`.
 [![Screencast how to install the CommunityModules into the TLA+ Toolbox](https://img.youtube.com/vi/w9t6JnmxV2E/0.jpg)](https://www.youtube.com/watch?v=w9t6JnmxV2E)
+
+If you are using the [VS Code extension](https://github.com/tlaplus/vscode-tlaplus), a recent version of the community modules is bundled with the nightly build. If you are not using the nightly build or need to use another version, see [this](https://github.com/tlaplus/vscode-tlaplus/issues/249).
+
+If you are running TLC via tla2tools.jar, ensure the JAR is on the *classpath*: either place it next to tla2tools.jar or add it explicitly with `java -cp tla2tools.jar:CommunityModules-deps.jar ...`.
 
 Being a community-driven repository puts the community in charge of checking the validity and correctness of submissions. The maintainers of this repository will try to keep this place in order. Still, we can't guarantee the quality of the modules and, therefore, cannot provide any assistance on eventual malfunctions.
 


### PR DESCRIPTION
I've forgotten and had to rediscover the different ways of using the community modules more than once, so this documents all of them.

In particular, the JAR has to be added to the [*classpath*](https://github.com/tlaplus/tlaplus/blob/master/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java#L220-L224), while `-DTLA-Library` only works for source files. The Toolbox adds things on its "TLA+ library path" to [*both*](https://github.com/tlaplus/tlaplus/blob/master/toolbox/org.lamport.tla.toolbox.tool.tlc/src/org/lamport/tla/toolbox/tool/tlc/job/TLCProcessJob.java#L112-L174) the classpath and `-DTLA-Library`.

Feel free to edit.

Also, when would one opt to use CommunityModules.jar over CommunityModules-deps.jar?