### PR TITLE
Remove use of deprecated `Applicable` interface

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,6 +31,7 @@
 		<javac srcdir="${src}" destdir="${build}/modules" classpath="${tlc}/tla2tools.jar:${lib}/gson-2.8.6.jar:${lib}/jgrapht-core-1.5.1.jar:${lib}/jungrapht-layout-1.4-SNAPSHOT.jar:${lib}/slf4j-api-1.7.30.jar:${lib}/slf4j-nop-1.7.30.jar:${lib}/commons-lang3-3.12.0.jar:${lib}/commons-math3-3.6.1.jar"
            source="1.8"
            target="1.8"
+           deprecation="true"
            includeantruntime="false"/>
 	</target>
 

--- a/modules/tlc2/overrides/BagsExt.java
+++ b/modules/tlc2/overrides/BagsExt.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2022 Inria. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -64,7 +65,7 @@ public final class BagsExt {
 									+ Values.ppr(domain[i].toString()) + ":>" + Values.ppr(values[i].toString()) + ")" });
 			}
 			for (int j = 0; j < ((IntValue) values[i]).val; j++) {
-				acc[0] = op.apply(acc, EvalControl.Clear);
+				acc[0] = op.eval(acc, EvalControl.Clear);
 			}
 		}
 

--- a/modules/tlc2/overrides/FiniteSetsExt.java
+++ b/modules/tlc2/overrides/FiniteSetsExt.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2020 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -30,7 +31,6 @@ import tlc2.tool.EvalControl;
 import tlc2.tool.EvalException;
 import tlc2.value.IBoolValue;
 import tlc2.value.Values;
-import tlc2.value.impl.Applicable;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.Enumerable;
 import tlc2.value.impl.EnumerableValue;
@@ -49,25 +49,19 @@ public class FiniteSetsExt {
 	}
 
 	@TLAPlusOperator(identifier = "Quantify", module = "FiniteSetsExt", warn = false)
-	public static Value quantify(final Value set, final Value pred) {
+	public static Value quantify(final Value set, final OpValue test) {
 		if (!(set instanceof EnumerableValue)) {
 			throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR,
 					new String[] { "first", "Quantify", "set", Values.ppr(set.toString()) });
 		}
-		if (!(pred instanceof Applicable)) {
-			throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR,
-					new String[] { "second", "Quantify", "boolean-valued operator", Values.ppr(pred.toString()) });
-		}
-		
 		
 		int size = 0;
-		final Applicable test = (Applicable) pred;
 		final ValueEnumeration enumSet = ((SetEnumValue) set.toSetEnum()).elements();
         Value elem;
         final Value[] args = new Value[1];
 		while ((elem = enumSet.nextElement()) != null) {
 			args[0] = elem;
-			Value val = test.apply(args, EvalControl.Clear);
+			Value val = test.eval(args, EvalControl.Clear);
 			if (val instanceof IBoolValue) {
 				if (((BoolValue) val).val) {
 					size++;
@@ -112,10 +106,10 @@ public class FiniteSetsExt {
 		
 		final ValueEnumeration ve = set.elements();
 
-		Value v = null;
+		Value v;
 		while ((v = ve.nextElement()) != null) {
 			args[0] = v;
-			args[1] = op.apply(args, EvalControl.Clear);
+			args[1] = op.eval(args, EvalControl.Clear);
 		}
 		
 		return args[1];

--- a/modules/tlc2/overrides/Functions.java
+++ b/modules/tlc2/overrides/Functions.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2019 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -31,10 +32,10 @@ import tlc2.output.EC;
 import tlc2.tool.EvalControl;
 import tlc2.tool.EvalException;
 import tlc2.value.Values;
-import tlc2.value.impl.Applicable;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.Enumerable;
 import tlc2.value.impl.FcnRcdValue;
+import tlc2.value.impl.FunctionValue;
 import tlc2.value.impl.OpValue;
 import tlc2.value.impl.SetOfRcdsValue;
 import tlc2.value.impl.TupleValue;
@@ -123,11 +124,11 @@ public final class Functions {
 		// Can assume type of OpValue because tla2sany.semantic.Generator.java will
 		// make sure that the first parameter is a binary operator.
 		
-		if (!(fun instanceof Applicable)) {
+		if (!(fun instanceof FunctionValue)) {
 			throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR,
 					new String[] { "third", "FoldFunction", "function", Values.ppr(fun.toString()) });
 		}
-		return foldFunctionOnSet(op, base, fun, ((Applicable) fun).getDomain());
+		return foldFunctionOnSet(op, base, fun, ((FunctionValue) fun).getDomain());
 	}
 
 	@TLAPlusOperator(identifier = "FoldFunctionOnSet", module = "Functions", warn = false)
@@ -135,11 +136,11 @@ public final class Functions {
 		// Can assume type of OpValue because tla2sany.semantic.Generator.java will
 		// make sure that the first parameter is a binary operator.
 
-		if (!(v3 instanceof Applicable)) {
+		if (!(v3 instanceof FunctionValue)) {
 			throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR,
 					new String[] { "third", "FoldFunctionOnSet", "function", Values.ppr(v3.toString()) });
 		}
-		final Applicable fun = (Applicable) v3;
+		final FunctionValue fun = (FunctionValue) v3;
 		if (!(v4 instanceof Enumerable)) {
 			throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR,
 					new String[] { "fourth", "FoldFunctionOnSet", "set", Values.ppr(v4.toString()) });
@@ -152,10 +153,10 @@ public final class Functions {
 
 		final ValueEnumeration ve = subdomain.elements();
 
-		Value v = null;
+		Value v;
 		while ((v = ve.nextElement()) != null) {
-			args[0] = fun.select(v);
-			args[1] = op.apply(args, EvalControl.Clear);
+			args[0] = fun.apply(v, EvalControl.Clear);
+			args[1] = op.eval(args, EvalControl.Clear);
 		}
 		
 		return args[1];

--- a/modules/tlc2/overrides/GraphViz.java
+++ b/modules/tlc2/overrides/GraphViz.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  *
@@ -27,7 +28,7 @@ package tlc2.overrides;
 
 import tlc2.tool.EvalControl;
 import tlc2.util.FP64;
-import tlc2.value.impl.Applicable;
+import tlc2.value.impl.OpValue;
 import tlc2.value.impl.RecordValue;
 import tlc2.value.impl.SetEnumValue;
 import tlc2.value.impl.StringValue;
@@ -38,23 +39,11 @@ import tlc2.value.impl.ValueEnumeration;
 public class GraphViz {
 
 	@TLAPlusOperator(identifier = "DotDiGraph", module = "GraphViz", warn = false)
-	public static Value dotDiGraph(final Value v1, final Value v2, final Value v3) throws Exception {
+	public static Value dotDiGraph(final Value v1, final OpValue vl, final OpValue el) throws Exception {
 		if (!(v1 instanceof RecordValue) || v1.toRcd() == null) {
 			throw new Exception("An DiGraph must be a record. Value given is of type: " + v1.getClass().getName());
 		}
 		final RecordValue g = (RecordValue) v1.toRcd();
-
-		if (!(v2 instanceof Applicable)) {
-			throw new Exception(
-					"Second parameter must be an Applicable. Value given is of type: " + v2.getClass().getName());
-		}
-		final Applicable vl = (Applicable) v2;
-
-		if (!(v3 instanceof Applicable)) {
-			throw new Exception(
-					"Third parameter must be an Applicable. Value given is of type: " + v2.getClass().getName());
-		}
-		final Applicable el = (Applicable) v3;
 
 		String dotString = "digraph MyGraph {";
 
@@ -65,7 +54,7 @@ public class GraphViz {
 		Value val = null;
 		while ((val = elements.nextElement()) != null) {
 			dotString += String.format("%s[label=%s];", val.fingerPrint(FP64.New()),
-					vl.apply(new Value[] { val }, EvalControl.Clear));
+					vl.eval(new Value[] { val }, EvalControl.Clear));
 		}
 
 		// Edges
@@ -75,7 +64,7 @@ public class GraphViz {
 		while ((val = elements.nextElement()) != null) {
 			TupleValue tv = (TupleValue) val.toTuple();
 			dotString += String.format("%s->%s[label=%s];", tv.elems[0].fingerPrint(FP64.New()),
-					tv.elems[1].fingerPrint(FP64.New()), el.apply(new Value[] { tv }, EvalControl.Clear));
+					tv.elems[1].fingerPrint(FP64.New()), el.eval(new Value[] { tv }, EvalControl.Clear));
 		}
 
 		dotString += "}";

--- a/modules/tlc2/overrides/VectorClocks.java
+++ b/modules/tlc2/overrides/VectorClocks.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  *
@@ -35,9 +36,9 @@ import java.util.Map;
 import java.util.Set;
 
 import tlc2.tool.EvalControl;
-import tlc2.value.impl.Applicable;
 import tlc2.value.impl.Enumerable;
 import tlc2.value.impl.IntValue;
+import tlc2.value.impl.OpValue;
 import tlc2.value.impl.TupleValue;
 import tlc2.value.impl.Value;
 import tlc2.value.impl.ValueEnumeration;
@@ -96,18 +97,18 @@ public class VectorClocks {
 	 * ff02d48ed2bcda065f326aa25409cb317be9feb9/js/model/modelGraph.js
 	 */
 	@TLAPlusOperator(identifier = "CausalOrder", module = "VectorClocks", warn = false)
-	public static Value causalOrder(final TupleValue v, final Applicable opClock, final Applicable opNode,
-			final Applicable opDomain) {
+	public static Value causalOrder(final TupleValue v, final OpValue opClock, final OpValue opNode,
+			final OpValue opDomain) {
 
 		// A1) Sort each node's individual log which can be totally ordered.
 		final Map<Value, LinkedList<GraphNode>> n2l = new HashMap<>();
 		for (int j = 0; j < v.elems.length; j++) {
 			final Value val = v.elems[j];
 
-			final Value nodeId = opNode.apply(new Value[] { val }, EvalControl.Clear);
-			final Value vc = opClock.apply(new Value[] { val }, EvalControl.Clear);
+			final Value nodeId = opNode.eval(new Value[] { val }, EvalControl.Clear);
+			final Value vc = opClock.eval(new Value[] { val }, EvalControl.Clear);
 			final Value nodeTime = vc.select(new Value[] { nodeId });
-			final Enumerable dom = (Enumerable) opDomain.apply(new Value[] { vc }, EvalControl.Clear).toSetEnum();
+			final Enumerable dom = (Enumerable) opDomain.eval(new Value[] { vc }, EvalControl.Clear).toSetEnum();
 
 			final LinkedList<GraphNode> list = n2l.computeIfAbsent(nodeId, k -> new LinkedList<GraphNode>());
 			list.add(new GraphNode(vc, nodeTime, dom, val));


### PR DESCRIPTION
The `Applicable` interface was recently deprecated; see tlaplus/tlaplus#843 for justification and more information.

This PR replaces uses of `Applicable` with more precise types (`FunctionValue` or `OpValue`).

It also makes a few minor orthogonal changes:
 - Show full information about deprecated APIs during the build; currently there are none :)
 - Remove some unnecessary instanceof checks and casts; SANY will verify that `OpValue` flows to any parameter declared with >0 arity in the .tla file, so overrides can simply take `OpValue` for those parameters. This was already the pattern in many places (e.g. `BagsExt.foldBag`) and it is now the pattern everywhere.