### PR TITLE
Tree check: cycle-free , rooted tree..

### DIFF
--- a/modules/Graphs.tla
+++ b/modules/Graphs.tla
@@ -63,8 +63,9 @@ IsTreeWithRoot(G, r) ==
   /\ IsDirectedGraph(G)
   /\ (Cardinality(G.node) = 1 => G.node = {r})
      \* Handles single-node tree case
-  /\ \A n \in G.node \ {r} : \E! f \in G.edge : f[2] = n
-     \* Every node except the root has exactly one incoming edge
+  /\ \A n \in G.node \ {r} :
+      LET incomingEdges == {f \in G.edge : f[2] = n}
+      IN Cardinality(incomingEdges) = 1
   /\ \A n \in G.node \ {r} : AreConnectedIn(r, n, G)
      \* Every node other than the root is reachable from the root
   /\ \A n \in G.node \ {r} : ~\E path \in SimplePath(G) : path[1] = n /\ path[Len(path)] = n

--- a/modules/Graphs.tla
+++ b/modules/Graphs.tla
@@ -61,17 +61,9 @@ IsStronglyConnected(G) ==
 -----------------------------------------------------------------------------
 IsTreeWithRoot(G, r) ==
   /\ IsDirectedGraph(G)
-  /\ r \in G.node
-  /\ \* root has no incoming edges
-     \A n \in G.node : <<n, r>> \notin G.edge
-  /\ \* every non-root node has exactly one incoming edge
-     \A n \in G.node \ {r} : 
-        /\ \E m \in G.node : <<m, n>> \in G.edge
-        /\ \A x \in G.node : <<x, n>> \in G.edge => x = m
-  /\ \* graph is connected from the root
-     \A n \in G.node \ {r} : AreConnectedIn(r, n, G)
-  /\ \* no cycles
-     \A n \in G.node : ~AreConnectedIn(n, n, G)
+  /\ \A e \in G.edge : /\ e[2] # r
+                       /\ \A f \in G.edge : (e[2] = f[2]) => (e = f)
+  /\ \A n \in G.node : AreConnectedIn(n, r, G)
 
 =============================================================================
 \* Modification History

--- a/modules/Graphs.tla
+++ b/modules/Graphs.tla
@@ -61,11 +61,18 @@ IsStronglyConnected(G) ==
 -----------------------------------------------------------------------------
 IsTreeWithRoot(G, r) ==
   /\ IsDirectedGraph(G)
-  /\ \A e \in G.edge : /\ e[1] # r
-                       /\ \A f \in G.edge : (e[1] = f[1]) => (e = f)
-  /\ \A n \in G.node : AreConnectedIn(n, r, G)
+  /\ (Cardinality(G.node) = 1 => G.node = {r})
+     \* Handles single-node tree case
+  /\ \A n \in G.node \ {r} : \E! f \in G.edge : f[2] = n
+     \* Every node except the root has exactly one incoming edge
+  /\ \A n \in G.node \ {r} : AreConnectedIn(r, n, G)
+     \* Every node other than the root is reachable from the root
+  /\ \A n \in G.node \ {r} : ~\E path \in SimplePath(G) : path[1] = n /\ path[Len(path)] = n
+     \* No cycles: No path from a node to itself
+
 =============================================================================
 \* Modification History
+\* Last modified Sun Dec 24 14:31:00 CET 2023 by Younes Akhouayri
 \* Last modified Sun Mar 06 18:10:34 CET 2022 by Stephan Merz
 \* Last modified Tue Dec 21 15:55:45 PST 2021 by Markus Kuppe
 \* Created Tue Jun 18 11:44:08 PST 2002 by Leslie Lamport

--- a/modules/Graphs.tla
+++ b/modules/Graphs.tla
@@ -61,15 +61,17 @@ IsStronglyConnected(G) ==
 -----------------------------------------------------------------------------
 IsTreeWithRoot(G, r) ==
   /\ IsDirectedGraph(G)
-  /\ (Cardinality(G.node) = 1 => G.node = {r})
-     \* Handles single-node tree case
-  /\ \A n \in G.node \ {r} :
-      LET incomingEdges == {f \in G.edge : f[2] = n}
-      IN Cardinality(incomingEdges) = 1
-  /\ \A n \in G.node \ {r} : AreConnectedIn(r, n, G)
-     \* Every node other than the root is reachable from the root
-  /\ \A n \in G.node \ {r} : ~\E path \in SimplePath(G) : path[1] = n /\ path[Len(path)] = n
-     \* No cycles: No path from a node to itself
+  /\ r \in G.node
+  /\ \* root has no incoming edges
+     \A n \in G.node : <<n, r>> \notin G.edge
+  /\ \* every non-root node has exactly one incoming edge
+     \A n \in G.node \ {r} : 
+        /\ \E m \in G.node : <<m, n>> \in G.edge
+        /\ \A x \in G.node : <<x, n>> \in G.edge => x = m
+  /\ \* graph is connected from the root
+     \A n \in G.node \ {r} : AreConnectedIn(r, n, G)
+  /\ \* no cycles
+     \A n \in G.node : ~AreConnectedIn(n, n, G)
 
 =============================================================================
 \* Modification History


### PR DESCRIPTION
Updated the `IsTreeWithRoot(G, r)` function to more accurately define a rooted tree in a graph

- Ensure single-node trees are correctly handled
- Each node, except the root, is now guaranteed to have exactly one incoming edge
- Verify that all nodes (except the root) are reachable from the root
- Add a check to prevent any cycles in the graph


Please let me know your thoughts..