### PR TITLE
Add IsRestriction to Functions

### DIFF
--- a/modules/Functions.tla
+++ b/modules/Functions.tla
@@ -150,6 +150,23 @@ FoldFunctionOnSet(op(_,_), base, fun, indices) ==
   (***************************************************************************)
   MapThenFoldSet(op, base, LAMBDA i : fun[i], LAMBDA s: CHOOSE x \in s : TRUE, indices)
 
+  (***************************************************************************)
+  (* Check if a function narrow is a restriction of a function wide, i.e.    *)
+  (* Is the domain of narrow a subset of that of wide, and does the          *)
+  (* projection of wide on the domain of narrow have the same image as       *)
+  (* narrow does.                                                            *)
+  (*                                                                         *)
+  (* Examples:                                                               *)
+  (*   IsRestriction([one |-> 1], [one |-> 1, two |-> 2])                    *)
+  (*   IsRestriction([one |-> 1], [one |-> 1])                               *)
+  (*  ~IsRestriction([one |-> 1, two |-> 2], [one |-> 1, two |-> 3])         *)
+  (*  ~IsRestriction([one |-> 1], [2 |-> two])                               *)
+  (*  ~IsRestriction([one |-> 1, two |-> 2], [two |-> 2])                    *)
+  (***************************************************************************)
+IsRestriction(narrow, wide) ==
+    /\ DOMAIN narrow \subseteq DOMAIN wide
+    /\ \A x \in DOMAIN narrow: narrow[x] = wide[x]
+
 =============================================================================
 \* Modification History
 \* Last modified Tue Nov 01 08:46:11 CET 2022 by merz

--- a/tests/FunctionsTests.tla
+++ b/tests/FunctionsTests.tla
@@ -107,4 +107,10 @@ ASSUME
         g == ("a" :> 1 @@ "b" :> 1 @@ "c" :> 3)
     IN Pointwise(f,g,-) = ("a" :> 0 @@ "b" :> 0 @@ "c" :> (-1) )
 
+ASSUME IsRestriction([one |-> 1], [one |-> 1, two |-> 2])
+ASSUME IsRestriction([one |-> 1], [one |-> 1])
+ASSUME ~IsRestriction([one |-> 1, two |-> 2], [one |-> 1, two |-> 3])
+ASSUME ~IsRestriction([one |-> 1], [two |-> 2])
+ASSUME ~IsRestriction([one |-> 1, two |-> 2], [two |-> 2])
+
 =============================================================================


### PR DESCRIPTION
```
  (***************************************************************************)
  (* Check if a function narrow is a restriction of a function wide, i.e.    *)
  (* Is the domain of narrow a subset of that of wide, and does the          *)
  (* projection of wide on the domain of narrow have the same image as       *)
  (* narrow does.                                                            *)
  (*                                                                         *)
  (* Examples:                                                               *)
  (*   IsRestriction([one |-> 1], [one |-> 1, two |-> 2])                    *)
  (*   IsRestriction([one |-> 1], [one |-> 1])                               *)
  (*  ~IsRestriction([one |-> 1, two |-> 2], [one |-> 1, two |-> 3])         *)
  (*  ~IsRestriction([one |-> 1], [2 |-> two])                               *)
  (*  ~IsRestriction([one |-> 1, two |-> 2], [two |-> 2])                    *)
  (***************************************************************************)
IsRestriction(narrow, wide) ==
    /\ DOMAIN narrow \subseteq DOMAIN wide
    /\ \A x \in DOMAIN narrow: narrow[x] = wide[x]
```

Useful when comparing restrictions over for example the logs of two nodes in a distributed system.