### PR TITLE
Theorems for sum of constant function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,3 +98,40 @@ jobs:
         repository: tlaplus/tlaplus
         event-type: tlaplus-dispatch
         client-payload: '{"source": "CommunityModules"}'
+
+  tlaps:
+    name: Verify TLAPS proofs
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz
+          - os: macos-latest
+            asset: tlapm-1.6.0-pre-arm64-darwin.tar.gz
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download TLAPS 1.6.0-pre
+      run: |
+        curl -fsSL -o tlapm.tar.gz \
+          "https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/${{ matrix.asset }}"
+        tar -xzf tlapm.tar.gz
+        echo "$PWD/tlapm/bin" >> "$GITHUB_PATH"
+    - name: Show tlapm version
+      run: tlapm --version
+    - name: Show tlapm configuration
+      run: tlapm --config
+    - name: Verify _proofs.tla modules
+      working-directory: modules
+      run: |
+        status=0
+        for proof in *_proofs.tla; do
+          echo "::group::Verifying $proof"
+          tlapm --cleanfp "$proof" || status=1
+          echo "::endgroup::"
+        done
+        exit $status

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,3 +22,40 @@ jobs:
       run: echo "date=$(date +'%Y%m%d%H%M')" >> "$GITHUB_OUTPUT"
     - name: Build with Ant
       run: ant -noinput -buildfile build.xml -Dtimestamp=${{steps.date.outputs.date}}
+
+  tlaps:
+    name: Verify TLAPS proofs
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz
+          - os: macos-latest
+            asset: tlapm-1.6.0-pre-arm64-darwin.tar.gz
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download TLAPS 1.6.0-pre
+      run: |
+        curl -fsSL -o tlapm.tar.gz \
+          "https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/${{ matrix.asset }}"
+        tar -xzf tlapm.tar.gz
+        echo "$PWD/tlapm/bin" >> "$GITHUB_PATH"
+    - name: Show tlapm version
+      run: tlapm --version
+    - name: Show tlapm configuration
+      run: tlapm --config
+    - name: Verify _proofs.tla modules
+      working-directory: modules
+      run: |
+        status=0
+        for proof in *_proofs.tla; do
+          echo "::group::Verifying $proof"
+          tlapm --cleanfp "$proof" || status=1
+          echo "::endgroup::"
+        done
+        exit $status

--- a/modules/FiniteSetsExtTheorems_proofs.tla
+++ b/modules/FiniteSetsExtTheorems_proofs.tla
@@ -550,7 +550,11 @@ THEOREM MaxIntBounded ==
 THEOREM MaxInterval ==
     ASSUME NEW a \in Int, NEW b \in Int, a <= b 
     PROVE  Max(a..b) = b
-BY DEF Max
+<1>1. b \in a..b
+  OBVIOUS
+<1>2. \A y \in a..b : b >= y
+  OBVIOUS
+<1>. QED  BY <1>1, <1>2, MaxInt
 
 THEOREM MinInt ==
     ASSUME NEW S \in SUBSET Int, NEW x \in S, \A y \in S : x <= y
@@ -605,7 +609,11 @@ THEOREM MinIntBounded ==
 THEOREM MinInterval ==
     ASSUME NEW a \in Int, NEW b \in Int, a <= b 
     PROVE  Min(a..b) = a
-BY DEF Min 
+<1>1. a \in a..b
+  OBVIOUS
+<1>2. \A y \in a..b : a <= y
+  OBVIOUS
+<1>. QED  BY <1>1, <1>2, MinInt
 
 THEOREM MinNat ==
     ASSUME NEW S \in SUBSET Nat, S # {}

--- a/modules/FunctionTheorems.tla
+++ b/modules/FunctionTheorems.tla
@@ -768,6 +768,18 @@ THEOREM SumFunctionOnSetZero ==
   PROVE  SumFunctionOnSet(fun, S) = 0 <=> \A x \in S : fun[x] = 0
 
 (*************************************************************************)
+(* Given any Int-valued function f and finite set S such that f[s] = c   *)
+(* for all s \in S, summing f over S yields c multiplied by the          *)
+(* cardinality of S. For example, for                                    *)
+(*   f == [s \in {"a", "b", "c"} |-> IF s = "c" THEN 42 ELSE 5],         *)
+(*   SumFunctionOnSet(f, {"a","b"}) = 10.                                *)
+(*************************************************************************)
+THEOREM SumFunctionOnSetConst ==
+  ASSUME NEW D, NEW S \in SUBSET D, IsFiniteSet(S),
+         NEW f \in [D -> Int], NEW c \in Int, \A x \in S : f[x] = c 
+  PROVE  SumFunctionOnSet(f, S) = c * Cardinality(S)
+
+(*************************************************************************)
 (* Summing a function is monotonic in the function argument.             *)
 (*************************************************************************)
 THEOREM SumFunctionOnSetMonotonic ==
@@ -824,6 +836,15 @@ THEOREM SumFunctionZero ==
   ASSUME NEW fun, IsFiniteSet(DOMAIN fun), 
          \A x \in DOMAIN fun : fun[x] \in Nat
   PROVE  SumFunction(fun) = 0 <=> \A x \in DOMAIN fun : fun[x] = 0
+
+(*************************************************************************)
+(* Summing a constant function yields the constant multiplied by the     *)
+(* cardinality of its domain. For example,                               *)
+(*   SumFunction([s \in {"a","b","c"} |-> 5]) = 15.                      *)
+(*************************************************************************)
+THEOREM SumFunctionConst ==
+  ASSUME NEW S, IsFiniteSet(S), NEW c \in Int
+  PROVE  SumFunction([s \in S |-> c]) = c * Cardinality(S)
 
 THEOREM SumFunctionMonotonic ==
   ASSUME NEW f, IsFiniteSet(DOMAIN f), NEW g, DOMAIN g = DOMAIN f,

--- a/modules/FunctionTheorems_proofs.tla
+++ b/modules/FunctionTheorems_proofs.tla
@@ -879,7 +879,16 @@ THEOREM Fun_NatBijSingleton ==
   ASSUME NEW S
   PROVE  ExistsBijection(1..1,S) <=> \E s : S = {s}
 <1>1. ASSUME NEW f \in Bijection(1..1, S)  PROVE \E s : S = {s}
-  BY 1..1 = {1} DEF Bijection, Surjection
+  <2>1. f \in [1..1 -> S] /\ \A t \in S : \E i \in 1..1 : f[i] = t
+    BY DEF Bijection, Injection, Surjection
+  <2>2. f[1] \in S
+    BY <2>1
+  <2>3. \A t \in S : t = f[1]
+    <3>1. TAKE t \in S
+    <3>2. PICK i \in 1..1 : f[i] = t  BY <2>1
+    <3>. QED  BY <3>2
+  <2>. WITNESS f[1]
+  <2>. QED  BY <2>2, <2>3
 <1>2. ASSUME NEW s, S = {s}  PROVE [i \in 1..1 |-> s] \in Bijection(1..1, S)
   BY <1>2 DEF Bijection, Injection, IsInjective, Surjection
 <1>. QED  BY <1>1, <1>2 DEF ExistsBijection

--- a/modules/FunctionTheorems_proofs.tla
+++ b/modules/FunctionTheorems_proofs.tla
@@ -1311,6 +1311,33 @@ THEOREM SumFunctionOnSetZero ==
   <2>. QED   BY DEF P
 
 (*************************************************************************)
+(* Given any Int-valued function f and finite set S such that f[s] = c   *)
+(* for all s \in S, summing f over S yields c multiplied by the          *)
+(* cardinality of S.                                                     *)
+(*************************************************************************)
+THEOREM SumFunctionOnSetConst ==
+  ASSUME NEW D, NEW S \in SUBSET D, IsFiniteSet(S),
+         NEW f \in [D -> Int], NEW c \in Int, \A x \in S : f[x] = c 
+  PROVE  SumFunctionOnSet(f, S) = c * Cardinality(S)
+<1>. DEFINE P(T) == SumFunctionOnSet(f, T) = c * Cardinality(T)
+<1>1. P({})
+  <2>1. SumFunctionOnSet(f, {}) = 0
+    BY SumFunctionOnSetEmpty
+  <2>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <2>. QED  BY <2>1, <2>2
+<1>2. ASSUME NEW T \in SUBSET S, IsFiniteSet(T), P(T), NEW x \in S \ T
+      PROVE  P(T \union {x})
+  <2>1. SumFunctionOnSet(f, T \union {x}) = c + SumFunctionOnSet(f, T)
+    BY <1>2, SumFunctionOnSetAddIndex
+  <2>2. Cardinality(T \union {x}) = Cardinality(T) + 1
+    BY <1>2, FS_AddElement
+  <2>3. Cardinality(T) \in Nat 
+    BY <1>2, FS_CardinalityType
+  <2>. QED  BY <1>2, <2>1, <2>2, <2>3
+<1>. QED  BY <1>1, <1>2, FS_Induction, IsaM("iprover")
+
+(*************************************************************************)
 (* Summing a function is monotonic in the function argument.             *)
 (*************************************************************************)
 THEOREM SumFunctionOnSetMonotonic ==
@@ -1400,6 +1427,11 @@ THEOREM SumFunctionZero ==
          \A x \in DOMAIN fun : fun[x] \in Nat
   PROVE  SumFunction(fun) = 0 <=> \A x \in DOMAIN fun : fun[x] = 0
 BY SumFunctionOnSetZero DEF SumFunction 
+
+THEOREM SumFunctionConst ==
+  ASSUME NEW S, IsFiniteSet(S), NEW c \in Int
+  PROVE  SumFunction([s \in S |-> c]) = c * Cardinality(S)
+BY SumFunctionOnSetConst DEF SumFunction
 
 THEOREM SumFunctionMonotonic ==
   ASSUME NEW f, IsFiniteSet(DOMAIN f), NEW g, DOMAIN g = DOMAIN f,


### PR DESCRIPTION
#### Summary

Adds two new theorems to `FunctionTheorems` for summing a constant function over a finite set:

- `SumFunctionOnSetConst` — for any finite `S` and constant `k`, `FoldFunctionOnSet(+, 0, [x \in S |-> k], S) = k * Cardinality(S)`.
- `SumFunctionConst` — the same fact stated for `FoldFunction` on a function whose domain is finite.

Both come with full TLAPS proofs in `FunctionTheorems_proofs` and a short example in the doc comments.

#### Supporting changes

To make sure these (and the other `*_proofs.tla` modules) stay valid as the library evolves, this PR also:

- Adds a `tlaps` GitHub Actions job to `main.yml` and `pr.yml` that downloads the TLAPS 1.6.0-pre release from `tlaplus/tlapm` and runs `tlapm` on every `modules/*_proofs.tla` file. The job runs as a matrix on `ubuntu-latest` (x86_64-linux-gnu) and `macos-latest` (arm64-darwin) and checks all proof files even when one fails, so a single regression doesn't mask others.
- Decomposes two existing one-liner proofs that happened to pass with the macOS arm64 TLAPS bundle but failed with the Linux x86_64 bundle, so the CI job is green on both platforms:
  - `Fun_NatBijSingleton` (singleton case) in `FunctionTheorems_proofs` no longer asks the SMT pipeline to unfold `Bijection`/`Surjection` and invent the existential witness in one step; it extracts typing/surjection facts, derives `f[1] \in S`, proves uniqueness via `PICK` on `1..1`, and `WITNESS`es `f[1]`.
  - `MaxInterval` / `MinInterval` in `FiniteSetsExtTheorems_proofs` no longer rely on a backend reasoning about the raw `CHOOSE` from `Max`/`Min` while doing arithmetic on `a..b`; they go through the existing `MaxInt` / `MinInt` introduction rules with the trivial side conditions supplied explicitly.

All 795 obligations of `FunctionTheorems_proofs` and 419 obligations of `FiniteSetsExtTheorems_proofs` continue to check locally with `tlapm --cleanfp`.

[Feature][Proofs][CI]