### PR TITLE
ci: pass --strict when verifying TLAPS proofs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
         status=0
         for proof in *_proofs.tla; do
           echo "::group::Verifying $proof"
-          tlapm --cleanfp "$proof" || status=1
+          tlapm --strict --cleanfp "$proof" || status=1
           echo "::endgroup::"
         done
         exit $status

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
         status=0
         for proof in *_proofs.tla; do
           echo "::group::Verifying $proof"
-          tlapm --cleanfp "$proof" || status=1
+          tlapm --strict --cleanfp "$proof" || status=1
           echo "::endgroup::"
         done
         exit $status


### PR DESCRIPTION
The TLAPS job runs

```sh
tlapm --cleanfp "$proof" || status=1
```

but `tlapm` exits 0 even when obligations fail, so `|| status=1` never fires and the job reports success over a proof that did not close. Context in tlaplus/tlapm#287; `--strict` was added in tlaplus/tlapm#278 and gives distinct non-zero codes for failed obligations (10), incomplete proofs (11), and empty targets (12).

**This is not a latent failure here.** I ran all six `_proofs.tla` modules against `tlapm 1.6.0-pre` (`096df83`), with and without the flag:

| module | exit with `--strict` | result |
|---|---|---|
| `FiniteSetsExtTheorems_proofs.tla` | 0 | All 431 obligations proved |
| `FoldsTheorems_proofs.tla` | 0 | All 244 obligations proved |
| `FunctionTheorems_proofs.tla` | 0 | All 771 obligations proved |
| `GraphTheorems_proofs.tla` | 0 | All 506 obligations proved |
| `QuorumTheorems_proofs.tla` | 0 | All 7 obligations proved |
| `SequencesExtTheorems_proofs.tla` | 0 | All 930 obligations proved |

Aggregate status is 0 both with and without `--strict`, so this changes nothing today. It makes the job fail if a future change breaks one of those 2,889 obligations, which it currently would not.

Run: https://github.com/vasilisnasopoulos-stack/vortex-dse-cslot-proofs/actions/runs/30570917693
